### PR TITLE
Implement the Simple Average Aggregator

### DIFF
--- a/src/services/marketRate/types.ts
+++ b/src/services/marketRate/types.ts
@@ -119,6 +119,19 @@ export function calculateMedian(values: number[]): number {
 }
 
 /**
+ * Calculate the simple average (arithmetic mean) of an array of numbers.
+ * Used to produce one final price from multiple source prices (e.g. NGN).
+ * @param prices - Array of price numbers from different sources
+ * @returns The arithmetic mean, or 0 for an empty array
+ */
+export function calculateAverage(prices: number[]): number {
+  if (prices.length === 0) return 0;
+
+  const sum = prices.reduce((acc, price) => acc + price, 0);
+  return sum / prices.length;
+}
+
+/**
  * Rate Fetch Statistics
  * Performance and reliability metrics
  */

--- a/test/calculateAverage.test.ts
+++ b/test/calculateAverage.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for calculateAverage
+ * Run with: npx tsx test/calculateAverage.test.ts
+ */
+import { calculateAverage } from '../src/services/marketRate/types.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(description: string, actual: number, expected: number): void {
+  // Use a small epsilon for floating-point comparisons
+  const ok = Math.abs(actual - expected) < 1e-10;
+  if (ok) {
+    console.log(`  ✅ PASS — ${description}`);
+    passed++;
+  } else {
+    console.error(`  ❌ FAIL — ${description}`);
+    console.error(`        expected: ${expected}`);
+    console.error(`        received: ${actual}`);
+    failed++;
+  }
+}
+
+console.log('\n🧮 calculateAverage — unit tests\n');
+
+// 1. Empty array must not crash and must return 0
+assert('empty array returns 0', calculateAverage([]), 0);
+
+// 2. Single price is the average of itself
+assert('single price [1500] → 1500', calculateAverage([1500]), 1500);
+
+// 3. Two prices
+assert('two prices [1000, 2000] → 1500', calculateAverage([1000, 2000]), 1500);
+
+// 4. Three NGN prices (the task's canonical scenario)
+assert(
+  'three NGN prices [1580, 1600, 1620] → 1600',
+  calculateAverage([1580, 1600, 1620]),
+  1600,
+);
+
+// 5. Floating-point inputs
+assert(
+  'float prices [1.1, 2.2, 3.3] → 2.2',
+  calculateAverage([1.1, 2.2, 3.3]),
+  2.2,
+);
+
+// 6. All identical prices
+assert(
+  'identical prices [500, 500, 500] → 500',
+  calculateAverage([500, 500, 500]),
+  500,
+);
+
+// 7. Zero included
+assert('prices with zero [0, 300] → 150', calculateAverage([0, 300]), 150);
+
+console.log(`\n📊 Results: ${passed} passed, ${failed} failed\n`);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
Close: #12 

Implementing Simple Average Aggregator
Added calculateAverage to src/services/marketRate/types.ts alongside calculateMedian, and created test/calculateAverage.test.ts with 7 test cases."

Done. Here's what was added:
src/services/marketRate/types.ts — new exported function right next to calculateMedian:
ts
export function calculateAverage(prices: number[]): number {
  if (prices.length === 0) return 0;
  const sum = prices.reduce((acc, price) => acc + price, 0);
  return sum / prices.length;
}

