### PR TITLE
feat(database): add Prisma schema for price history

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,14 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model PriceRecord {
+  id        Int      @id @default(autoincrement())
+  currency  String
+  value     Float
+  timestamp DateTime
+}


### PR DESCRIPTION
Closes #13

---

Here’s a clean PR description you can use:

**Title**
`feat(database): add Prisma schema for price history`

**Description**
## Summary
This PR adds the initial Prisma schema setup for storing price history records.

## Changes
- Added `prisma/schema.prisma`
- Defined a `PriceRecord` model
- Added fields:
  - `currency` as `String`
  - `value` as `Float`
  - `timestamp` as `DateTime`
- Added `prisma.config.ts` to support Prisma 7 datasource configuration
- Included an `id` primary key so the model is valid in Prisma

## Why
This sets up the database model needed to persist historical price data for currencies in the backend.

## Validation
- Verified the Prisma schema with:
  - `.\node_modules\.bin\prisma.cmd validate`

## Notes
- Prisma 7 requires datasource configuration in `prisma.config.ts`, so the connection URL is defined there instead of in `schema.prisma`.