### PR TITLE
feat:Implement Transaction Fee Estimator

### DIFF
--- a/src/services/stellarService.ts
+++ b/src/services/stellarService.ts
@@ -32,6 +32,18 @@ export class StellarService {
   }
 
   /**
+   * Fetches the recommended transaction fee from Horizon fee_stats.
+   * Uses p50 (median) of recent fees to avoid overpaying while ensuring inclusion.
+   * @returns Recommended fee in stroops as a string (required by TransactionBuilder)
+   */
+  async getRecommendedFee(): Promise<string> {
+    const feeStats = await this.server.feeStats();
+    // p50 = median fee paid in recent ledgers — safe and cost-efficient
+    const fee = parseInt(feeStats.fee_charged.p50, 10);
+    return Math.max(fee, 100).toString(); // floor at Stellar's base fee (100 stroops)
+  }
+
+  /**
    * Submit a price update to the Stellar network with a unique memo ID
    * @param currency - The currency code (e.g., "NGN", "KES")
    * @param price - The current price/rate
@@ -41,8 +53,9 @@ export class StellarService {
     try {
       const sourceAccount = await this.server.loadAccount(this.keypair.publicKey());
       
+      const fee = await this.getRecommendedFee();
       const transaction = new TransactionBuilder(sourceAccount, {
-        fee: "100", // Standard fee in stroops
+        fee,
         networkPassphrase: this.network === "PUBLIC" ? Networks.PUBLIC : Networks.TESTNET,
       })
         .addOperation(


### PR DESCRIPTION
## feat: implement dynamic transaction fee estimator

What
Replace hardcoded fee: "100" in submitPriceUpdate with a live fee estimate from Horizon's /fee_stats endpoint.

Why
A static 100 stroops fee works under normal conditions but risks slow inclusion during network congestion. 
Overpaying is equally wasteful. Using the p50 (median) of recently charged fees gives us the optimal balance — 
cost-efficient and reliably included.

### Changes
- src/services/stellarService.ts — added getRecommendedFee() to StellarService; wired it into submitPriceUpdate

### Logic
- Calls server.feeStats() (SDK-native, no new HTTP client)
- Uses fee_charged.p50 — median of fees paid in recent ledgers
- Floors at 100 stroops (Stellar's base minimum) to guard against idle-network edge cases

## Closes: #15 