### PR TITLE
Add Slack/Discord webhook for price fetch errors

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+
+# Webhook Configuration
+SLACK_WEBHOOK_URL=
+# DISCORD_WEBHOOK_URL=
+NOTIFICATION_PLATFORM=slack

--- a/src/services/errorTracker.ts
+++ b/src/services/errorTracker.ts
@@ -1,0 +1,29 @@
+cat > src/services/errorTracker.ts << 'EOF'
+export class ErrorTracker {
+  private failureCounters: Map<string, { count: number; errors: any[] }> = new Map();
+  private readonly threshold = 3;
+
+  trackFailure(serviceKey: string, errorDetails: any): boolean {
+    const existing = this.failureCounters.get(serviceKey);
+    if (existing) {
+      existing.count++;
+      existing.errors.push(errorDetails);
+      this.failureCounters.set(serviceKey, existing);
+      return existing.count >= this.threshold;
+    } else {
+      this.failureCounters.set(serviceKey, { count: 1, errors: [errorDetails] });
+      return false;
+    }
+  }
+
+  trackSuccess(serviceKey: string): void {
+    this.failureCounters.delete(serviceKey);
+  }
+
+  reset(serviceKey: string): void {
+    this.failureCounters.delete(serviceKey);
+  }
+}
+
+export const errorTracker = new ErrorTracker();
+EOF

--- a/src/services/marketRate/ghsFetcher.ts
+++ b/src/services/marketRate/ghsFetcher.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 import { MarketRateFetcher, MarketRate, calculateMedian } from "./types";
+import { errorTracker } from "../errorTracker";
+import { webhookService } from "../webhook";
 
 type CoinGeckoPriceResponse = {
   stellar?: {
@@ -57,6 +59,9 @@ export class GHSRateFetcher implements MarketRateFetcher {
           timestamp: lastUpdatedAt,
           source: "CoinGecko (direct)",
         });
+        
+        // Success - reset error tracker
+        errorTracker.trackSuccess("GHS-price-fetch");
       }
     } catch (error) {
       console.debug("CoinGecko direct GHS price failed");
@@ -109,6 +114,9 @@ export class GHSRateFetcher implements MarketRateFetcher {
               fxTimestamp > lastUpdatedAt ? fxTimestamp : lastUpdatedAt,
             source: "CoinGecko + ExchangeRate API",
           });
+          
+          // Success - reset error tracker
+          errorTracker.trackSuccess("GHS-price-fetch");
         }
       }
     } catch (error) {
@@ -150,6 +158,9 @@ export class GHSRateFetcher implements MarketRateFetcher {
               timestamp: new Date(),
               source: "Alternative XLM pricing",
             });
+            
+            // Success - reset error tracker
+            errorTracker.trackSuccess("GHS-price-fetch");
           }
         }
       }
@@ -174,7 +185,26 @@ export class GHSRateFetcher implements MarketRateFetcher {
       };
     }
 
-    throw new Error("All GHS rate sources failed");
+    // All strategies failed - track failure and send notification if 3 consecutive failures
+    const error = new Error("All GHS rate sources failed");
+    const thresholdReached = errorTracker.trackFailure("GHS-price-fetch", {
+      errorMessage: error.message,
+      timestamp: new Date(),
+      service: "GHSRateFetcher",
+    });
+    
+    if (thresholdReached) {
+      await webhookService.sendErrorNotification({
+        errorType: "PRICE_FETCH_FAILED_CONSECUTIVE",
+        errorMessage: error.message,
+        attempts: 3,
+        service: "GHSRateFetcher",
+        pricePair: "XLM/GHS",
+        timestamp: new Date(),
+      });
+    }
+    
+    throw error;
   }
 
   async isHealthy(): Promise<boolean> {

--- a/src/services/webhook.ts
+++ b/src/services/webhook.ts
@@ -1,0 +1,88 @@
+cat > src/services/webhook.ts << 'EOF'
+import axios from 'axios';
+
+export class WebhookService {
+  private webhookUrl: string | undefined;
+  private platform: string;
+
+  constructor() {
+    this.webhookUrl = process.env.SLACK_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_URL;
+    this.platform = process.env.NOTIFICATION_PLATFORM || 'slack';
+  }
+
+  async sendErrorNotification(errorDetails: {
+    errorType: string;
+    errorMessage: string;
+    attempts: number;
+    service: string;
+    pricePair: string;
+    timestamp: Date;
+  }): Promise<void> {
+    if (!this.webhookUrl) return;
+
+    const message = this.formatMessage(errorDetails);
+
+    try {
+      await axios.post(this.webhookUrl!, message, {
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 5000,
+      });
+    } catch (error) {
+      console.error('Failed to send webhook notification:', error);
+    }
+  }
+
+  private formatMessage(errorDetails: {
+    errorType: string;
+    errorMessage: string;
+    attempts: number;
+    service: string;
+    pricePair: string;
+    timestamp: Date;
+  }): any {
+    const { errorMessage, attempts, service, pricePair, timestamp } = errorDetails;
+
+    if (this.platform === 'discord') {
+      return {
+        embeds: [
+          {
+            title: '🚨 Price Fetch Error',
+            color: 0xff0000,
+            fields: [
+              { name: 'Service', value: service, inline: true },
+              { name: 'Price Pair', value: pricePair, inline: true },
+              { name: 'Failed Attempts', value: attempts.toString(), inline: true },
+              { name: 'Error', value: errorMessage.substring(0, 500) },
+              { name: 'Time', value: new Date(timestamp).toISOString() },
+            ],
+          },
+        ],
+      };
+    }
+
+    return {
+      blocks: [
+        {
+          type: 'header',
+          text: { type: 'plain_text', text: '🚨 Price Fetch Error' },
+        },
+        {
+          type: 'section',
+          fields: [
+            { type: 'mrkdwn', text: `*Service:*\n${service}` },
+            { type: 'mrkdwn', text: `*Price Pair:*\n${pricePair}` },
+            { type: 'mrkdwn', text: `*Failed Attempts:*\n${attempts}/3` },
+            { type: 'mrkdwn', text: `*Time:*\n${new Date(timestamp).toISOString()}` },
+          ],
+        },
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: `*Error:*\n\`\`\`${errorMessage.substring(0, 500)}\`\`\`` },
+        },
+      ],
+    };
+  }
+}
+
+export const webhookService = new WebhookService();
+EOF


### PR DESCRIPTION
## Description
Send a message to dev channel when price fetch fails 3 times in a row.

## Changes Made
- Added `ErrorTracker` service to track consecutive failures
- Added `WebhookService` for Slack/Discord notifications
- Integrated with `GHSRateFetcher` to trigger notification after 3 failures
- Added environment variables for webhook configuration

## Configuration
Add to `.env`:
- `SLACK_WEBHOOK_URL` or `DISCORD_WEBHOOK_URL`
- `NOTIFICATION_PLATFORM` (slack or discord)

## Files Added/Modified
- `src/services/errorTracker.ts` (new)
- `src/services/webhook.ts` (new)
- `src/services/marketRate/ghsFetcher.ts` (modified)
- `.env` (new)

## Related Issue
# Close #37