### PR TITLE
Add Provider Reputation table to track API reliability

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,3 +58,34 @@ model PriceRecord {
   value     Float
   timestamp DateTime
 }
+
+// Provider Reputation Model
+// Tracks API reliability and performance
+model ProviderReputation {
+  id              Int       @id @default(autoincrement())
+  providerName    String    @db.VarChar(100)  // e.g., "CoinGecko", "ExchangeRateAPI"
+  endpoint        String?   @db.VarChar(255)  // Specific endpoint URL or identifier
+  status          String    @db.VarChar(20)   // "online", "offline", "degraded"
+  totalRequests   Int       @default(0)       // Total API calls made
+  successfulRequests Int    @default(0)       // Successful responses
+  failedRequests  Int       @default(0)       // Failed responses
+  incorrectResponses Int   @default(0)        // Responses with invalid/incorrect data
+  averageLatency  Float?    @db.Float         // Average response time in ms
+  lastSuccess     DateTime?                    // Last successful response timestamp
+  lastFailure     DateTime?                    // Last failed response timestamp
+  lastIncorrect   DateTime?                    // Last incorrect response timestamp
+  consecutiveFailures Int  @default(0)        // Current streak of consecutive failures
+  consecutiveIncorrect Int @default(0)        // Current streak of consecutive incorrect responses
+  
+  // Reliability metrics
+  reliabilityScore Float?   @db.Float         // Calculated score (0-100)
+  lastUpdated     DateTime  @updatedAt
+  
+  createdAt       DateTime  @default(now())
+  
+  // Indexes for quick lookups
+  @@index([providerName])
+  @@index([status])
+  @@index([reliabilityScore])
+  @@unique([providerName, endpoint])
+}

--- a/src/services/reputation.service.ts
+++ b/src/services/reputation.service.ts
@@ -1,0 +1,171 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export class ReputationService {
+  async recordSuccess(providerName: string, endpoint: string | null, latencyMs?: number): Promise<void> {
+    const existing = await prisma.providerReputation.findUnique({
+      where: {
+        providerName_endpoint: {
+          providerName,
+          endpoint: endpoint || '',
+        },
+      },
+    });
+
+    const newTotalRequests = (existing?.totalRequests || 0) + 1;
+    const newSuccessfulRequests = (existing?.successfulRequests || 0) + 1;
+    const newConsecutiveFailures = 0;
+    const newConsecutiveIncorrect = 0;
+    
+    // Calculate new average latency
+    let newAvgLatency = existing?.averageLatency || null;
+    if (latencyMs && existing?.averageLatency) {
+      newAvgLatency = (existing.averageLatency * existing.successfulRequests + latencyMs) / newSuccessfulRequests;
+    } else if (latencyMs) {
+      newAvgLatency = latencyMs;
+    }
+    
+    // Calculate reliability score
+    const reliabilityScore = (newSuccessfulRequests / newTotalRequests) * 100;
+    
+    await prisma.providerReputation.upsert({
+      where: {
+        providerName_endpoint: {
+          providerName,
+          endpoint: endpoint || '',
+        },
+      },
+      update: {
+        totalRequests: newTotalRequests,
+        successfulRequests: newSuccessfulRequests,
+        averageLatency: newAvgLatency,
+        lastSuccess: new Date(),
+        consecutiveFailures: newConsecutiveFailures,
+        consecutiveIncorrect: newConsecutiveIncorrect,
+        status: 'online',
+        reliabilityScore,
+        lastUpdated: new Date(),
+      },
+      create: {
+        providerName,
+        endpoint: endpoint || '',
+        status: 'online',
+        totalRequests: 1,
+        successfulRequests: 1,
+        averageLatency: latencyMs || null,
+        lastSuccess: new Date(),
+        reliabilityScore: 100,
+      },
+    });
+  }
+
+  async recordFailure(providerName: string, endpoint: string | null, errorType: 'offline' | 'incorrect'): Promise<void> {
+    const existing = await prisma.providerReputation.findUnique({
+      where: {
+        providerName_endpoint: {
+          providerName,
+          endpoint: endpoint || '',
+        },
+      },
+    });
+
+    const newTotalRequests = (existing?.totalRequests || 0) + 1;
+    const newFailedRequests = (existing?.failedRequests || 0) + 1;
+    let newConsecutiveFailures = (existing?.consecutiveFailures || 0) + 1;
+    let newConsecutiveIncorrect = existing?.consecutiveIncorrect || 0;
+    
+    if (errorType === 'incorrect') {
+      newConsecutiveIncorrect = (existing?.consecutiveIncorrect || 0) + 1;
+    }
+    
+    // Determine status based on consecutive failures
+    let status = 'online';
+    if (newConsecutiveFailures >= 5) {
+      status = 'offline';
+    } else if (newConsecutiveFailures >= 2) {
+      status = 'degraded';
+    }
+    
+    // Calculate reliability score
+    const successfulRequests = existing?.successfulRequests || 0;
+    const reliabilityScore = (successfulRequests / newTotalRequests) * 100;
+    
+    await prisma.providerReputation.upsert({
+      where: {
+        providerName_endpoint: {
+          providerName,
+          endpoint: endpoint || '',
+        },
+      },
+      update: {
+        totalRequests: newTotalRequests,
+        failedRequests: newFailedRequests,
+        lastFailure: new Date(),
+        consecutiveFailures: newConsecutiveFailures,
+        ...(errorType === 'incorrect' && {
+          incorrectResponses: (existing?.incorrectResponses || 0) + 1,
+          lastIncorrect: new Date(),
+          consecutiveIncorrect: newConsecutiveIncorrect,
+        }),
+        status,
+        reliabilityScore,
+        lastUpdated: new Date(),
+      },
+      create: {
+        providerName,
+        endpoint: endpoint || '',
+        status: 'degraded',
+        totalRequests: 1,
+        failedRequests: 1,
+        lastFailure: new Date(),
+        consecutiveFailures: 1,
+        ...(errorType === 'incorrect' && {
+          incorrectResponses: 1,
+          lastIncorrect: new Date(),
+          consecutiveIncorrect: 1,
+        }),
+        reliabilityScore: 0,
+      },
+    });
+  }
+
+  async getReputation(providerName: string, endpoint?: string): Promise<any> {
+    return prisma.providerReputation.findUnique({
+      where: {
+        providerName_endpoint: {
+          providerName,
+          endpoint: endpoint || '',
+        },
+      },
+    });
+  }
+
+  async getLowReliabilityProviders(threshold: number = 80): Promise<any[]> {
+    return prisma.providerReputation.findMany({
+      where: {
+        reliabilityScore: { lt: threshold },
+        totalRequests: { gt: 10 },
+      },
+      orderBy: { reliabilityScore: 'asc' },
+    });
+  }
+
+  async resetConsecutiveFailures(providerName: string, endpoint?: string): Promise<void> {
+    await prisma.providerReputation.update({
+      where: {
+        providerName_endpoint: {
+          providerName,
+          endpoint: endpoint || '',
+        },
+      },
+      data: {
+        consecutiveFailures: 0,
+        consecutiveIncorrect: 0,
+        status: 'online',
+      },
+    });
+  }
+}
+
+export const reputationService = new ReputationService();


### PR DESCRIPTION
## Description
Add database table to track how many times a specific API was offline or returned incorrect data.

## Changes Made
- Added `ProviderReputation` model to Prisma schema with fields:
  - `providerName`, `endpoint` - identify the API
  - `successfulRequests`, `failedRequests`, `incorrectResponses` - counters
  - `consecutiveFailures`, `consecutiveIncorrect` - streak tracking
  - `reliabilityScore` - calculated score (0-100)
  - `status` - online/degraded/offline
- Added `ReputationService` with methods:
  - `recordSuccess()` - update on successful API call
  - `recordFailure()` - update on failed/incorrect response
  - `getReputation()` - query reputation for a provider
  - `getLowReliabilityProviders()` - find providers needing attention

## Files Added/Modified
- `prisma/schema.prisma` - added ProviderReputation model
- `src/services/reputation.service.ts` - new service

## Database Migration
After merging, run:
```bash
npx prisma migrate dev --name add_provider_reputation
npx prisma generate

Closes #31