### PR TITLE
fix: Implement Maintenance Mode middleware (#167)

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 DATABASE_URL=postgresql://dummy:dummy@localhost:5432/dummy
+MAINTENANCE_MODE=false

--- a/MAINTENANCE_MODE.md
+++ b/MAINTENANCE_MODE.md
@@ -1,0 +1,42 @@
+# Maintenance Mode Implementation
+
+## Overview
+This project now supports a Maintenance Mode feature, allowing the API to return HTTP 503 Service Unavailable during upgrades or maintenance windows.
+
+## How It Works
+- **Toggle Location:** The maintenance flag is controlled via the `MAINTENANCE_MODE` environment variable in the `.env` file.
+- **Behavior:**
+  - When `MAINTENANCE_MODE=true`, all API endpoints (except those explicitly allowlisted) will return a 503 status with a maintenance message.
+  - When `MAINTENANCE_MODE=false`, the API operates normally.
+- **Middleware:** A new middleware (`maintenanceMiddleware.ts`) checks the flag and enforces maintenance mode.
+- **Allowlist:** Health check and status endpoints are allowlisted and remain accessible during maintenance.
+
+## Usage
+1. **Enable Maintenance Mode:**
+   - Set `MAINTENANCE_MODE=true` in the `.env` file.
+   - Restart the server (if using process.env directly).
+2. **Disable Maintenance Mode:**
+   - Set `MAINTENANCE_MODE=false` in the `.env` file.
+   - Restart the server.
+
+## Allowlisted Endpoints
+- `/status`
+- `/health` (if present)
+
+## Extending Functionality
+- To make the flag dynamic (e.g., toggle via DB or admin API), refactor the middleware to check the DB or cache instead of process.env.
+- To allow more endpoints, add their paths to the allowlist in the middleware.
+
+## Testing
+- With maintenance mode enabled, all non-allowlisted endpoints should return 503.
+- With maintenance mode disabled, all endpoints should function normally.
+
+## Files Changed/Added
+- `.env` (added/updated)
+- `src/middleware/maintenanceMiddleware.ts` (added)
+- `src/app.ts` or `src/index.ts` (middleware integrated)
+- `MAINTENANCE_MODE.md` (this documentation)
+
+---
+
+For further customization or questions, see the comments in the middleware or contact the maintainers.

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import derivedAssetsRouter from "./routes/derivedAssets";
 import adminRouter from "./routes/admin";
 import { apiKeyMiddleware } from "./middleware/apiKeyMiddleware";
 import { rateLimitMiddleware } from "./middleware/rateLimitMiddleware";
+import { maintenanceMiddleware } from "./middleware/maintenanceMiddleware";
 import { specs } from "./lib/swagger";
 
 dotenv.config();
@@ -28,6 +29,9 @@ const dashboardUrl =
   "http://localhost:3000";
 
 app.use(morgan("dev"));
+
+// Maintenance mode middleware: must be early in the chain
+app.use(maintenanceMiddleware);
 app.use(
   cors({
     origin: (origin, callback) => {

--- a/src/middleware/maintenanceMiddleware.ts
+++ b/src/middleware/maintenanceMiddleware.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express';
+
+// Allowlisted endpoints that should remain accessible during maintenance
+const allowlist = [
+  '/status',
+  '/health', // Add more paths as needed
+];
+
+/**
+ * Middleware to enforce maintenance mode.
+ * Reads MAINTENANCE_MODE from process.env (set in .env).
+ * Returns 503 Service Unavailable for all endpoints except allowlisted ones.
+ */
+export function maintenanceMiddleware(req: Request, res: Response, next: NextFunction) {
+  const isMaintenance = process.env.MAINTENANCE_MODE === 'true';
+  // Allow allowlisted endpoints
+  if (isMaintenance && !allowlist.includes(req.path)) {
+    return res.status(503).json({
+      message: 'Service is under maintenance. Please try again later.',
+      maintenance: true,
+    });
+  }
+  next();
+}

--- a/test/maintenanceMode.test.ts
+++ b/test/maintenanceMode.test.ts
@@ -1,0 +1,29 @@
+import request from 'supertest';
+import app from '../src/app';
+
+describe('Maintenance Mode', () => {
+  const originalEnv = process.env.MAINTENANCE_MODE;
+
+  afterEach(() => {
+    process.env.MAINTENANCE_MODE = originalEnv;
+  });
+
+  it('should return 503 for non-allowlisted endpoints when maintenance mode is enabled', async () => {
+    process.env.MAINTENANCE_MODE = 'true';
+    const res = await request(app).get('/api/v1/market-rates/rates');
+    expect(res.status).toBe(503);
+    expect(res.body).toHaveProperty('maintenance', true);
+  });
+
+  it('should allow allowlisted endpoints during maintenance', async () => {
+    process.env.MAINTENANCE_MODE = 'true';
+    const res = await request(app).get('/status');
+    expect(res.status).not.toBe(503);
+  });
+
+  it('should allow all endpoints when maintenance mode is disabled', async () => {
+    process.env.MAINTENANCE_MODE = 'false';
+    const res = await request(app).get('/api/v1/market-rates/rates');
+    expect(res.status).not.toBe(503);
+  });
+});


### PR DESCRIPTION
- Adds a MAINTENANCE_MODE flag in .env to toggle maintenance mode
- Returns HTTP 503 for all non-allowlisted endpoints when enabled
- Allowlists /status and /health endpoints for uptime checks
- Integrates middleware early in the Express chain
- Adds documentation (MAINTENANCE_MODE.md) and tests


Closes #167