### PR TITLE
feat: add K6 load testing scripts for latest-prices endpoint

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,81 @@
+# K6 Load Tests
+
+Load testing scripts for the StellarFlow backend using [k6](https://k6.io).
+
+## Prerequisites
+
+Install k6:
+
+```bash
+# macOS
+brew install k6
+
+# Linux
+sudo snap install k6
+
+# Docker
+docker pull grafana/k6
+```
+
+## Scripts
+
+| Script | Purpose | Duration |
+|--------|---------|----------|
+| `smoke.js` | Sanity check — 1 VU, all endpoints | ~30s |
+| `latest-prices.js` | 1,000 RPS sustained on `/api/v1/market-rates/latest` | 1m |
+| `stress.js` | Ramp up past 1,000 RPS to find breaking point | ~8m |
+| `soak.js` | 1,000 RPS for 30 minutes (memory/leak detection) | ~30m |
+
+## Running
+
+Always run the smoke test first to confirm the server is healthy:
+
+```bash
+k6 run tests/load/smoke.js
+```
+
+Main load test (1,000 RPS target):
+
+```bash
+k6 run tests/load/latest-prices.js
+```
+
+Against a non-local server, set `BASE_URL`:
+
+```bash
+k6 run -e BASE_URL=https://your-server.example.com tests/load/latest-prices.js
+```
+
+Stress test (find breaking point):
+
+```bash
+k6 run tests/load/stress.js
+```
+
+Soak test (sustained 30 minutes):
+
+```bash
+k6 run tests/load/soak.js
+```
+
+## Thresholds
+
+The `latest-prices.js` script fails if:
+- Error rate ≥ 1%
+- p95 latency > 500ms
+- p99 latency > 1,000ms
+
+## Output
+
+k6 prints a summary after each run. Key metrics to watch:
+
+- `http_req_duration` — response time percentiles
+- `http_req_failed` — error rate
+- `http_reqs` — actual RPS achieved
+- `request_latency` — custom latency trend
+
+To export results as JSON:
+
+```bash
+k6 run --out json=results.json tests/load/latest-prices.js
+```

--- a/tests/load/latest-prices.js
+++ b/tests/load/latest-prices.js
@@ -1,0 +1,63 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend, Counter } from "k6/metrics";
+
+const errorRate = new Rate("error_rate");
+const latency = new Trend("request_latency", true);
+const requestCount = new Counter("request_count");
+
+// Target: 1,000 requests per second sustained for 1 minute
+export const options = {
+  scenarios: {
+    latest_prices_load: {
+      executor: "constant-arrival-rate",
+      rate: 1000,
+      timeUnit: "1s",
+      duration: "1m",
+      preAllocatedVUs: 200,
+      maxVUs: 500,
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],       // <1% error rate
+    http_req_duration: ["p(95)<500"],     // 95% of requests under 500ms
+    http_req_duration: ["p(99)<1000"],    // 99% of requests under 1s
+    error_rate: ["rate<0.01"],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+
+export default function () {
+  const url = `${BASE_URL}/api/v1/market-rates/latest`;
+
+  const res = http.get(url, {
+    headers: { "Content-Type": "application/json" },
+    timeout: "10s",
+  });
+
+  const success = check(res, {
+    "status is 200": (r) => r.status === 200,
+    "response has success field": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return body.success === true;
+      } catch {
+        return false;
+      }
+    },
+    "response has data field": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return body.data !== undefined;
+      } catch {
+        return false;
+      }
+    },
+    "response time < 500ms": (r) => r.timings.duration < 500,
+  });
+
+  errorRate.add(!success);
+  latency.add(res.timings.duration);
+  requestCount.add(1);
+}

--- a/tests/load/smoke.js
+++ b/tests/load/smoke.js
@@ -1,0 +1,41 @@
+/**
+ * Smoke test — run this first to confirm the server is up and endpoints
+ * respond correctly before running heavier load tests.
+ *
+ * Usage: k6 run tests/load/smoke.js
+ */
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+export const options = {
+  vus: 1,
+  duration: "30s",
+  thresholds: {
+    http_req_failed: ["rate==0"],
+    http_req_duration: ["p(95)<1000"],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+
+const ENDPOINTS = [
+  { name: "latest prices", url: `${BASE_URL}/api/v1/market-rates/latest` },
+  { name: "all rates", url: `${BASE_URL}/api/v1/market-rates/rates` },
+  { name: "status", url: `${BASE_URL}/api/v1/status` },
+  { name: "NGN rate", url: `${BASE_URL}/api/v1/market-rates/rate/NGN` },
+  { name: "GHS rate", url: `${BASE_URL}/api/v1/market-rates/rate/GHS` },
+  { name: "KES rate", url: `${BASE_URL}/api/v1/market-rates/rate/KES` },
+];
+
+export default function () {
+  for (const endpoint of ENDPOINTS) {
+    const res = http.get(endpoint.url, { timeout: "10s" });
+
+    check(res, {
+      [`${endpoint.name}: status 200`]: (r) => r.status === 200,
+      [`${endpoint.name}: has body`]: (r) => r.body && r.body.length > 0,
+    });
+
+    sleep(0.5);
+  }
+}

--- a/tests/load/soak.js
+++ b/tests/load/soak.js
@@ -1,0 +1,50 @@
+/**
+ * Soak test — runs the 1,000 RPS target for an extended period to detect
+ * memory leaks, connection pool exhaustion, and database degradation.
+ *
+ * Usage: k6 run tests/load/soak.js
+ * Note:  Expect this to run for ~35 minutes.
+ */
+import http from "k6/http";
+import { check } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+const errorRate = new Rate("error_rate");
+const latency = new Trend("request_latency", true);
+
+export const options = {
+  scenarios: {
+    soak: {
+      executor: "constant-arrival-rate",
+      rate: 1000,
+      timeUnit: "1s",
+      duration: "30m",
+      preAllocatedVUs: 200,
+      maxVUs: 500,
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<500"],
+    // latency must not degrade over time — keep p99 under 1s throughout
+    http_req_duration: ["p(99)<1000"],
+    error_rate: ["rate<0.01"],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+
+export default function () {
+  const res = http.get(`${BASE_URL}/api/v1/market-rates/latest`, {
+    headers: { "Content-Type": "application/json" },
+    timeout: "10s",
+  });
+
+  const success = check(res, {
+    "status 200": (r) => r.status === 200,
+    "response time < 500ms": (r) => r.timings.duration < 500,
+  });
+
+  errorRate.add(!success);
+  latency.add(res.timings.duration);
+}

--- a/tests/load/stress.js
+++ b/tests/load/stress.js
@@ -1,0 +1,53 @@
+/**
+ * Stress test — ramps up past the 1,000 RPS target to find the
+ * breaking point and observe how the server degrades.
+ *
+ * Usage: k6 run tests/load/stress.js
+ */
+import http from "k6/http";
+import { check } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+const errorRate = new Rate("error_rate");
+const latency = new Trend("request_latency", true);
+
+export const options = {
+  scenarios: {
+    stress_ramp: {
+      executor: "ramping-arrival-rate",
+      startRate: 100,
+      timeUnit: "1s",
+      preAllocatedVUs: 200,
+      maxVUs: 1000,
+      stages: [
+        { duration: "1m", target: 500 },   // ramp to 500 RPS
+        { duration: "2m", target: 1000 },  // ramp to 1,000 RPS (target)
+        { duration: "2m", target: 1500 },  // push to 1,500 RPS
+        { duration: "2m", target: 2000 },  // push to 2,000 RPS
+        { duration: "1m", target: 0 },     // ramp down
+      ],
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.05"],      // allow up to 5% errors under stress
+    http_req_duration: ["p(95)<2000"],   // 95% under 2s under stress
+    error_rate: ["rate<0.05"],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+
+export default function () {
+  const res = http.get(`${BASE_URL}/api/v1/market-rates/latest`, {
+    headers: { "Content-Type": "application/json" },
+    timeout: "15s",
+  });
+
+  const success = check(res, {
+    "status 200": (r) => r.status === 200,
+    "no server error": (r) => r.status < 500,
+  });
+
+  errorRate.add(!success);
+  latency.add(res.timings.duration);
+}


### PR DESCRIPTION
## Summary

- Adds `tests/load/` with four K6 scripts to verify the backend sustains **1,000 requests per second** against `GET /api/v1/market-rates/latest`
- Introduces a progressive testing strategy: smoke → load → stress → soak
- Each script is independently runnable via `k6 run <script>` and accepts a `BASE_URL` env var for targeting any environment

## Scripts

| Script | Executor | Target RPS | Duration | Purpose |
|--------|----------|------------|----------|---------|
| `smoke.js` | shared-iterations (1 VU) | ~2 RPS | 30s | Sanity-check all key endpoints before heavier runs |
| `latest-prices.js` | constant-arrival-rate | **1,000 RPS** | 1m | Core load test — verifies the 1K RPS requirement |
| `stress.js` | ramping-arrival-rate | up to 2,000 RPS | ~8m | Find the breaking point beyond the target |
| `soak.js` | constant-arrival-rate | 1,000 RPS | 30m | Detect memory leaks and connection pool exhaustion |

## Thresholds (latest-prices.js)

- `http_req_failed` < 1%
- `p(95)` latency < 500ms
- `p(99)` latency < 1,000ms

## Test plan

- [ ] Install k6 (`brew install k6`)
- [ ] Start the backend locally (`npm run dev`)
- [ ] Run smoke test: `k6 run tests/load/smoke.js`
- [ ] Run main load test: `k6 run tests/load/latest-prices.js`
- [ ] Confirm all thresholds pass in k6 summary output

Closes #170