### PR TITLE
feat: Add database migration auto-validation on startup (#164)

### DIFF
--- a/DB_VALIDATION_IMPLEMENTATION.md
+++ b/DB_VALIDATION_IMPLEMENTATION.md
@@ -1,0 +1,95 @@
+# Database Migration Auto-Validation Implementation
+
+## Issue #164
+
+### Overview
+This implementation adds automatic database schema validation on server startup to prevent the server from starting if the database schema is out of sync with the Prisma schema.
+
+### Changes Made
+
+#### 1. New Utility: `src/utils/dbValidator.ts`
+Created a comprehensive database validation utility that performs three checks:
+
+1. **Prisma Schema Validation**: Runs `prisma validate` to ensure the schema file is syntactically correct
+2. **Database Connection Check**: Verifies the database is accessible
+3. **Migration Status Check**: Runs `prisma migrate status` to detect pending migrations
+
+The validator will:
+- ✅ Pass if all checks succeed
+- ❌ Fail and prevent server startup if:
+  - Prisma schema is invalid
+  - Database connection fails
+  - There are pending migrations
+- ⚠️ Warn but continue if migration status check fails (e.g., command not found)
+
+#### 2. Integration: `src/index.ts`
+Added the validation check early in the startup sequence:
+```typescript
+// [OPS] Validate database schema on startup
+await validateDatabaseSchema();
+```
+
+This runs after environment validation but before any database operations.
+
+#### 3. Test Coverage: `test/dbValidator.test.ts`
+Created comprehensive unit tests covering:
+- Successful validation scenario
+- Prisma schema validation failure
+- Database connection failure
+- Pending migrations detection
+- Migration status command failure (graceful degradation)
+- No pending migrations scenario
+
+### Usage
+
+#### Normal Startup
+When the database is in sync, you'll see:
+```
+🔍 Validating database schema...
+✅ Prisma schema validation passed
+✅ Database connection successful
+✅ Database schema is up to date
+✅ Database validation completed successfully
+```
+
+#### When Migrations Are Pending
+The server will fail to start with:
+```
+❌ Database has pending migrations
+❌ Database validation failed!
+The server cannot start because the database schema is not valid or out of sync.
+
+To fix this issue:
+  1. Run: npm run db:migrate
+  2. Or run: npx prisma migrate deploy
+  3. Or run: npm run db:push (for development)
+```
+
+### Benefits
+
+1. **Prevents Runtime Errors**: Catches schema mismatches before the server starts accepting requests
+2. **Clear Error Messages**: Provides actionable guidance on how to fix issues
+3. **Developer Experience**: Saves debugging time by failing fast with clear instructions
+4. **Production Safety**: Ensures deployments don't proceed with incompatible schemas
+
+### Testing
+
+Run the tests with:
+```bash
+npm run test:jest -- dbValidator.test.ts
+```
+
+### Deployment Considerations
+
+For production deployments:
+1. Run migrations before starting the server: `npx prisma migrate deploy`
+2. Or include migration in your deployment pipeline
+3. The validation will catch any missed migrations and prevent startup
+
+### Future Enhancements
+
+Potential improvements:
+- Add option to auto-apply migrations in development mode
+- Add schema version tracking in database
+- Add Slack/webhook notifications for schema validation failures
+- Add metrics/monitoring for validation checks

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { enableGlobalLogMasking } from "./utils/logMasker";
 import { hourlyAverageService } from "./services/hourlyAverageService";
 import { metricsMiddleware, metricsEndpoint } from "./middleware/metrics";
 import { watchConfig } from "./config/configWatcher";
+import { validateDatabaseSchema } from "./utils/dbValidator";
 
 // Load environment variables
 dotenv.config();
@@ -24,6 +25,9 @@ enableGlobalLogMasking();
 
 // [OPS] Implement "Environment Variable" Check on Start
 validateEnv();
+
+// [OPS] Validate database schema on startup
+await validateDatabaseSchema();
 
 // Validate required environment variables
 const requiredEnvVars = ["STELLAR_SECRET", "DATABASE_URL"] as const;

--- a/src/utils/dbValidator.ts
+++ b/src/utils/dbValidator.ts
@@ -1,0 +1,90 @@
+import { execSync } from "child_process";
+import prisma from "../lib/prisma";
+
+/**
+ * Validates that the database schema is in sync with Prisma schema
+ * @throws Error if validation fails or schema is out of sync
+ */
+export async function validateDatabaseSchema(): Promise<void> {
+  console.log("🔍 Validating database schema...");
+
+  try {
+    // Step 1: Run prisma validate to check schema syntax
+    try {
+      execSync("npx prisma validate", {
+        stdio: "pipe",
+        encoding: "utf-8",
+      });
+      console.log("Prisma schema validation passed");
+    } catch (error) {
+      console.error("Prisma schema validation failed");
+      throw new Error(
+        `Prisma schema validation failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    // Step 2: Check if database is accessible
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      console.log("Database connection successful");
+    } catch (error) {
+      console.error("Database connection failed");
+      throw new Error(
+        `Database connection failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    // Step 3: Check for pending migrations
+    try {
+      const result = execSync("npx prisma migrate status", {
+        stdio: "pipe",
+        encoding: "utf-8",
+      });
+
+      const output = result.toString();
+
+      // Check if there are pending migrations or database is out of sync
+      if (
+        output.includes("Database schema is up to date") ||
+        output.includes("No pending migrations")
+      ) {
+        console.log("Database schema is up to date");
+      } else if (
+        output.includes("following migration have not yet been applied") ||
+        output.includes("Your database schema is not in sync")
+      ) {
+        console.error("Database has pending migrations");
+        console.error("\nMigration status:");
+        console.error(output);
+        throw new Error(
+          "Database schema is out of sync. Please run 'npm run db:migrate' or 'npx prisma migrate deploy' to apply pending migrations.",
+        );
+      } else {
+        console.log("Database migration check completed");
+      }
+    } catch (error) {
+      // If the error is from our throw above, re-throw it
+      if (error instanceof Error && error.message.includes("out of sync")) {
+        throw error;
+      }
+
+      // For other errors (like command not found), log warning but don't fail
+      console.warn(
+        "⚠️  Could not check migration status:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+
+    console.log("Database validation completed successfully\n");
+  } catch (error) {
+    console.error("\nDatabase validation failed!");
+    console.error(
+      "The server cannot start because the database schema is not valid or out of sync.",
+    );
+    console.error("\nTo fix this issue:");
+    console.error("  1. Run: npm run db:migrate");
+    console.error("  2. Or run: npx prisma migrate deploy");
+    console.error("  3. Or run: npm run db:push (for development)\n");
+    throw error;
+  }
+}

--- a/test/dbValidator.test.ts
+++ b/test/dbValidator.test.ts
@@ -1,0 +1,121 @@
+import { execSync } from "node:child_process";
+import { validateDatabaseSchema } from "../src/utils/dbValidator";
+import prisma from "../src/lib/prisma";
+
+// Mock dependencies
+jest.mock("node:child_process");
+jest.mock("../src/lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    $queryRaw: jest.fn(),
+  },
+}));
+
+const mockedExecSync = execSync as jest.MockedFunction<typeof execSync>;
+const mockedPrisma = prisma as jest.Mocked<typeof prisma>;
+
+describe("Database Validator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Suppress console output during tests
+    jest.spyOn(console, "log").mockImplementation();
+    jest.spyOn(console, "error").mockImplementation();
+    jest.spyOn(console, "warn").mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("validateDatabaseSchema", () => {
+    it("should pass when schema is valid and up to date", async () => {
+      // Mock successful prisma validate
+      mockedExecSync.mockReturnValueOnce(Buffer.from("Schema is valid"));
+
+      // Mock successful database connection
+      mockedPrisma.$queryRaw.mockResolvedValueOnce([{ "?column?": 1 }]);
+
+      // Mock successful migration status
+      mockedExecSync.mockReturnValueOnce(
+        Buffer.from("Database schema is up to date"),
+      );
+
+      await expect(validateDatabaseSchema()).resolves.not.toThrow();
+    });
+
+    it("should throw error when prisma validate fails", async () => {
+      // Mock failed prisma validate
+      mockedExecSync.mockImplementationOnce(() => {
+        throw new Error("Invalid schema");
+      });
+
+      await expect(validateDatabaseSchema()).rejects.toThrow(
+        "Prisma schema validation failed",
+      );
+    });
+
+    it("should throw error when database connection fails", async () => {
+      // Mock successful prisma validate
+      mockedExecSync.mockReturnValueOnce(Buffer.from("Schema is valid"));
+
+      // Mock failed database connection
+      mockedPrisma.$queryRaw.mockRejectedValueOnce(
+        new Error("Connection refused"),
+      );
+
+      await expect(validateDatabaseSchema()).rejects.toThrow(
+        "Database connection failed",
+      );
+    });
+
+    it("should throw error when there are pending migrations", async () => {
+      // Mock successful prisma validate
+      mockedExecSync.mockReturnValueOnce(Buffer.from("Schema is valid"));
+
+      // Mock successful database connection
+      mockedPrisma.$queryRaw.mockResolvedValueOnce([{ "?column?": 1 }]);
+
+      // Mock pending migrations
+      mockedExecSync.mockReturnValueOnce(
+        Buffer.from(
+          "Your database schema is not in sync with your migration history",
+        ),
+      );
+
+      await expect(validateDatabaseSchema()).rejects.toThrow(
+        "Database schema is out of sync",
+      );
+    });
+
+    it("should pass when migration status check fails but other checks pass", async () => {
+      // Mock successful prisma validate
+      mockedExecSync.mockReturnValueOnce(Buffer.from("Schema is valid"));
+
+      // Mock successful database connection
+      mockedPrisma.$queryRaw.mockResolvedValueOnce([{ "?column?": 1 }]);
+
+      // Mock migration status command failure (e.g., command not found)
+      mockedExecSync.mockImplementationOnce(() => {
+        throw new Error("Command not found");
+      });
+
+      // Should not throw, just warn
+      await expect(validateDatabaseSchema()).resolves.not.toThrow();
+    });
+
+    it("should pass when no pending migrations message is present", async () => {
+      // Mock successful prisma validate
+      mockedExecSync.mockReturnValueOnce(Buffer.from("Schema is valid"));
+
+      // Mock successful database connection
+      mockedPrisma.$queryRaw.mockResolvedValueOnce([{ "?column?": 1 }]);
+
+      // Mock no pending migrations
+      mockedExecSync.mockReturnValueOnce(
+        Buffer.from("No pending migrations"),
+      );
+
+      await expect(validateDatabaseSchema()).resolves.not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
- Created dbValidator utility to check schema sync on startup
- Validates Prisma schema, DB connection, and migration status
- Prevents server start if DB schema is out of sync
- Added comprehensive test coverage
- Provides clear error messages with fix instructions

# fixes #164