### PR TITLE
feat: add latency guard for relayer payload validation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -172,3 +172,25 @@ model HourlyStats {
   @@unique([currency, hour])
   @@index([hour])
 }
+
+// Compliance Metadata Store for relayer performance auditing
+// Tracks latency violations and other compliance events
+model ComplianceMetadata {
+  id                Int       @id @default(autoincrement())
+  relayerId         Int?      // Optional link to relayer (if known)
+  relayerName       String?   @db.VarChar(100)  // Relayer name at time of violation
+  eventType         String    @db.VarChar(50)  // e.g., "LATENCY_VIOLATION", "PAYLOAD_REJECTED"
+  payloadTimestamp  DateTime? @db.Timestamp(3) // Timestamp from the relayer payload
+  receivedAt       DateTime  @db.Timestamp(3)  // When the payload was received
+  latencyDiffMs     Int?      // Calculated latency difference in milliseconds
+  thresholdMs       Int?      // The threshold that was exceeded
+  details           String?   @db.Text         // Additional JSON details about the event
+  resolved          Boolean   @default(false)  // Whether the violation has been addressed
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  @@index([relayerId])
+  @@index([eventType])
+  @@index([createdAt])
+  @@index([relayerName, createdAt])
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import cacheMetricsRouter from "./cache/CacheMetrics";
 import { specs } from "./lib/swagger";
 import { adminMiddleware } from "./middleware/adminMiddleware";
 import { apiKeyMiddleware } from "./middleware/apiKeyMiddleware";
+import { latencyValidationMiddleware } from "./middleware/latencyGuardMiddleware";
 import { maintenanceMiddleware } from "./middleware/maintenanceMiddleware";
 import { rateLimitMiddleware } from "./middleware/rateLimitMiddleware";
 import adminRouter from "./routes/admin";
@@ -94,6 +95,9 @@ app.get(
 app.use("/api", rateLimitMiddleware);
 app.use("/api", apiKeyMiddleware);
 app.use("/api/v1", apiKeyMiddleware);
+
+// Latency validation for relayer payloads - validates timestamps to prevent stale data
+app.use("/api/v1/price-updates", latencyValidationMiddleware);
 
 app.use("/api/admin", adminMiddleware, adminRouter);
 app.use("/api/v1/market-rates", marketRatesRouter);

--- a/src/middleware/latencyGuardMiddleware.ts
+++ b/src/middleware/latencyGuardMiddleware.ts
@@ -1,0 +1,226 @@
+import { Request, Response, NextFunction } from "express";
+import prisma from "../lib/prisma";
+import { getMaxLatencyMs } from "../utils/envValidator";
+
+/**
+ * Latency validation middleware for relayer payloads.
+ * 
+ * Validates that incoming relayer payloads are not "stale" by checking
+ * the timestamp difference between the payload and current time.
+ * 
+ * Expects payloads to have a `timestamp` field (ISO 8601 format).
+ * If the timestamp_diff exceeds MAX_LATENCY_MS threshold, the request is rejected.
+ * 
+ * Latency violations are logged to the ComplianceMetadataStore for auditing.
+ */
+export const latencyValidationMiddleware = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  // Skip validation if not a relayer request
+  if (!req.relayer) {
+    next();
+    return;
+  }
+
+  const maxLatencyMs = getMaxLatencyMs();
+  const payloadTimestamp = req.body.timestamp;
+
+  // If no timestamp in payload, allow through but log a warning
+  if (!payloadTimestamp) {
+    console.warn(
+      `[LatencyGuard] No timestamp in relayer payload. Relayer: ${req.relayer.name}. Allowing request but recommend adding timestamp.`,
+    );
+    next();
+    return;
+  }
+
+  try {
+    // Parse the payload timestamp
+    const payloadTime = new Date(payloadTimestamp).getTime();
+    
+    if (isNaN(payloadTime)) {
+      console.error(
+        `[LatencyGuard] Invalid timestamp format in relayer payload: ${payloadTimestamp}`,
+      );
+      await logLatencyViolation(
+        req.relayer.id,
+        req.relayer.name,
+        "INVALID_TIMESTAMP",
+        payloadTimestamp,
+        null,
+        maxLatencyMs,
+        { error: "Invalid timestamp format" },
+      );
+      
+      res.status(400).json({
+        success: false,
+        error: "Invalid timestamp format in payload",
+      });
+      return;
+    }
+
+    // Calculate latency difference
+    const now = Date.now();
+    const latencyDiff = now - payloadTime;
+
+    // Check if latency exceeds threshold
+    if (latencyDiff > maxLatencyMs) {
+      console.error(
+        `[LatencyGuard] LATENCY VIOLATION: Relayer "${req.relayer.name}" payload is ${latencyDiff}ms old (max: ${maxLatencyMs}ms)`,
+      );
+
+      // Log the violation to ComplianceMetadataStore
+      await logLatencyViolation(
+        req.relayer.id,
+        req.relayer.name,
+        "LATENCY_VIOLATION",
+        payloadTimestamp,
+        latencyDiff,
+        maxLatencyMs,
+        {
+          endpoint: req.path,
+          method: req.method,
+          bodyKeys: Object.keys(req.body).filter(k => k !== 'timestamp'),
+        },
+      );
+
+      res.status(400).json({
+        success: false,
+        error: `Payload timestamp exceeds maximum latency threshold (${maxLatencyMs}ms)`,
+        code: "LATENCY_VIOLATION",
+        details: {
+          payloadTimestamp,
+          latencyDiffMs: latencyDiff,
+          thresholdMs: maxLatencyMs,
+        },
+      });
+      return;
+    }
+
+    // Log successful validation for monitoring
+    console.debug(
+      `[LatencyGuard] Relayer "${req.relayer.name}" payload validated: ${latencyDiff}ms latency (max: ${maxLatencyMs}ms)`,
+    );
+
+    next();
+  } catch (error) {
+    console.error("[LatencyGuard] Error during latency validation:", error);
+    
+    // Log the error as a violation for auditing
+    await logLatencyViolation(
+      req.relayer.id,
+      req.relayer.name,
+      "VALIDATION_ERROR",
+      payloadTimestamp,
+      null,
+      maxLatencyMs,
+      { error: String(error) },
+    );
+
+    res.status(500).json({
+      success: false,
+      error: "Latency validation failed",
+    });
+  }
+};
+
+/**
+ * Logs a latency violation to the ComplianceMetadataStore for auditing.
+ */
+async function logLatencyViolation(
+  relayerId: number | undefined,
+  relayerName: string | undefined,
+  eventType: string,
+  payloadTimestamp: string | null,
+  latencyDiffMs: number | null,
+  thresholdMs: number,
+  details: object,
+): Promise<void> {
+  try {
+    await prisma.complianceMetadata.create({
+      data: {
+        relayerId: relayerId,
+        relayerName: relayerName,
+        eventType,
+        payloadTimestamp: payloadTimestamp ? new Date(payloadTimestamp) : null,
+        receivedAt: new Date(),
+        latencyDiffMs,
+        thresholdMs,
+        details: JSON.stringify(details),
+        resolved: false,
+      },
+    });
+    
+    console.info(`[LatencyGuard] Violation logged to ComplianceMetadataStore: ${eventType}`);
+  } catch (error) {
+    // Non-blocking: log error but don't fail the request
+    console.error("[LatencyGuard] Failed to log violation to ComplianceMetadataStore:", error);
+  }
+}
+
+/**
+ * Get compliance metadata for a specific relayer.
+ * Useful for auditing relayer performance.
+ */
+export async function getRelayerComplianceHistory(
+  relayerName?: string,
+  eventType?: string,
+  limit: number = 100,
+) {
+  const where: any = {};
+  
+  if (relayerName) {
+    where.relayerName = relayerName;
+  }
+  
+  if (eventType) {
+    where.eventType = eventType;
+  }
+
+  return prisma.complianceMetadata.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+}
+
+/**
+ * Get latency violation statistics for a relayer.
+ */
+export async function getRelayerLatencyStats(relayerName: string) {
+  const totalViolations = await prisma.complianceMetadata.count({
+    where: {
+      relayerName,
+      eventType: "LATENCY_VIOLATION",
+    },
+  });
+
+  const recentViolations = await prisma.complianceMetadata.findMany({
+    where: {
+      relayerName,
+      eventType: "LATENCY_VIOLATION",
+    },
+    orderBy: { createdAt: "desc" },
+    take: 10,
+    select: {
+      latencyDiffMs: true,
+      thresholdMs: true,
+      createdAt: true,
+    },
+  });
+
+  // Calculate average latency of violations
+  const avgLatency = recentViolations.length > 0
+    ? recentViolations.reduce((sum, v) => sum + (v.latencyDiffMs || 0), 0) / recentViolations.length
+    : 0;
+
+  return {
+    relayerName,
+    totalViolations,
+    recentViolationCount: recentViolations.length,
+    averageLatencyMs: Math.round(avgLatency),
+    recentViolations,
+  };
+}

--- a/src/utils/envValidator.ts
+++ b/src/utils/envValidator.ts
@@ -24,4 +24,33 @@ export function validateEnv() {
     // Exit the process with failure code
     process.exit(1);
   }
+
+  // Log optional but recommended environment variables
+  const recommendedEnvVars = ["MAX_LATENCY_MS"];
+  for (const envVar of recommendedEnvVars) {
+    if (!process.env[envVar]) {
+      console.warn(`⚠️ [OPS] Recommended environment variable not set: ${envVar}`);
+    } else {
+      console.info(`✅ [OPS] ${envVar} = ${process.env[envVar]}ms`);
+    }
+  }
+}
+
+/**
+ * Get the MAX_LATENCY_MS value from environment variables.
+ * @returns The latency threshold in milliseconds, or default 30000ms (30 seconds)
+ */
+export function getMaxLatencyMs(): number {
+  const envValue = process.env.MAX_LATENCY_MS;
+  if (envValue === undefined || envValue === "") {
+    return 30000; // Default: 30 seconds
+  }
+  const parsed = parseInt(envValue, 10);
+  if (isNaN(parsed) || parsed <= 0) {
+    console.warn(
+      `⚠️ [OPS] Invalid MAX_LATENCY_MS value: "${envValue}". Using default 30000ms.`,
+    );
+    return 30000;
+  }
+  return parsed;
 }


### PR DESCRIPTION
- Add MAX_LATENCY_MS environment variable with default 30s threshold
- Implement latencyValidationMiddleware to reject stale relayer payloads
- Add ComplianceMetadata model to schema for latency violation logging
- Integrate middleware into /api/v1/price-updates routes

Technical changes:
- envValidator.ts: Add getMaxLatencyMs() function and log recommended env vars
- latencyGuardMiddleware.ts: New middleware validates payload timestamps
- schema.prisma: Add ComplianceMetadata table for audit logging
- app.ts: Apply latency validation after API key authentication



# closes #203