### PR TITLE
feat: implement regional failover logic for Lagos/Frankfurt cluster s…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,14 @@ PORT=3000
 API_KEY=the_secret_api_key_here
 REDIS_URL=redis://localhost:6379
 
+# Regional failover configuration
+PRIMARY_CLUSTER_HEALTH_URL=https://lagos-backend.example.com
+SECONDARY_CLUSTER_HEALTH_URL=https://frankfurt-backend.example.com
+REGIONAL_HEARTBEAT_PATH=/health
+REGIONAL_HEARTBEAT_INTERVAL_MS=30000
+REGIONAL_HEARTBEAT_TIMEOUT_MS=5000
+FAILOVER_THRESHOLD=3
+
 # API Keys (optional - some rate sources may require)
 OPENEXCHANGE_RATES_API_KEY=your_api_key_here
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ import sanityCheckRouter from "./routes/sanityCheck";
 import statsRouter from "./routes/stats";
 import statusRouter from "./routes/status";
 import systemControlRouter from "./routes/systemControl";
+import systemFailoverRouter from "./routes/systemFailover";
 
 dotenv.config();
 
@@ -107,6 +108,7 @@ app.use("/api/v1/price-updates", latencyValidationMiddleware);
 
 app.use("/api/admin", adminMiddleware, adminRouter);
 app.use("/api/admin/system", adminMiddleware, systemControlRouter);
+app.use("/api/v1/system", adminMiddleware, systemFailoverRouter);
 app.use("/api/v1/market-rates", marketRatesRouter);
 app.use("/api/v1/history", historyRouter);
 app.use("/api/v1/stats", statsRouter);

--- a/src/controllers/systemFailoverController.ts
+++ b/src/controllers/systemFailoverController.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from "express";
+import { getRegionalHealthService } from "../services/regionalHealthService";
+
+type FailoverRegion = "PRIMARY" | "SECONDARY";
+
+export class SystemFailoverController {
+  async performFailover(req: Request, res: Response): Promise<void> {
+    try {
+      const { targetRegion } = req.body as { targetRegion?: FailoverRegion };
+
+      if (!targetRegion || (targetRegion !== "PRIMARY" && targetRegion !== "SECONDARY")) {
+        res.status(400).json({
+          success: false,
+          error: "Invalid or missing targetRegion. Expected 'PRIMARY' or 'SECONDARY'.",
+        });
+        return;
+      }
+
+      const service = getRegionalHealthService();
+      const state = await service.forceFailover(targetRegion);
+
+      res.status(200).json({
+        success: true,
+        message: `Manual failover applied. Active region is now ${state.activeRegion}.`,
+        data: state,
+      });
+    } catch (error) {
+      console.error("[SystemFailoverController] performFailover failed:", error);
+      res.status(500).json({
+        success: false,
+        error: "Could not perform manual failover",
+      });
+    }
+  }
+
+  async resetFailover(req: Request, res: Response): Promise<void> {
+    try {
+      const service = getRegionalHealthService();
+      const state = await service.resetManualOverride();
+
+      res.status(200).json({
+        success: true,
+        message: "Manual override reset. Automatic regional health monitoring is now active.",
+        data: state,
+      });
+    } catch (error) {
+      console.error("[SystemFailoverController] resetFailover failed:", error);
+      res.status(500).json({
+        success: false,
+        error: "Could not reset failover override",
+      });
+    }
+  }
+
+  async getFailoverStatus(req: Request, res: Response): Promise<void> {
+    try {
+      const service = getRegionalHealthService();
+      const state = service.getState();
+
+      res.status(200).json({
+        success: true,
+        data: state,
+      });
+    } catch (error) {
+      console.error("[SystemFailoverController] getFailoverStatus failed:", error);
+      res.status(500).json({
+        success: false,
+        error: "Could not retrieve failover status",
+      });
+    }
+  }
+}
+
+export const systemFailoverController = new SystemFailoverController();

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { multiSigSubmissionService } from "./services/multiSigSubmissionService"
 import { validateEnv } from "./utils/envValidator";
 import { enableGlobalLogMasking } from "./utils/logMasker";
 import { hourlyAverageService } from "./services/hourlyAverageService";
+import { getRegionalHealthService } from "./services/regionalHealthService";
 import { metricsMiddleware, metricsEndpoint } from "./middleware/metrics";
 import { watchConfig } from "./config/configWatcher";
 import { validateDatabaseSchema } from "./utils/dbValidator";
@@ -38,6 +39,9 @@ registerTracingShutdownHandlers();
 
 // Enable log masking to prevent sensitive data leaks
 enableGlobalLogMasking();
+
+// Start regional health monitoring before we accept requests.
+await getRegionalHealthService().startMonitoring();
 
 // [OPS] Implement "Environment Variable" Check on Start
 validateEnv();

--- a/src/routes/systemFailover.ts
+++ b/src/routes/systemFailover.ts
@@ -1,0 +1,103 @@
+import { Router } from "express";
+import { systemFailoverController } from "../controllers/systemFailoverController";
+
+const router = Router();
+
+/**
+ * @swagger
+ * /api/v1/system/failover:
+ *   post:
+ *     tags:
+ *       - System Control
+ *     summary: Manually switch the active regional backend cluster
+ *     description: Apply an administrative override to move traffic to either the Lagos primary cluster or the Frankfurt secondary cluster.
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - targetRegion
+ *             properties:
+ *               targetRegion:
+ *                 type: string
+ *                 enum: [PRIMARY, SECONDARY]
+ *                 description: Region to activate
+ *                 example: PRIMARY
+ *     responses:
+ *       '200':
+ *         description: Failover applied successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     activeRegion:
+ *                       type: string
+ *                     activeUrl:
+ *                       type: string
+ *       '400':
+ *         description: Invalid request payload
+ *       '403':
+ *         description: Forbidden
+ *       '500':
+ *         description: Server error
+ */
+router.post(
+  "/failover",
+  systemFailoverController.performFailover.bind(systemFailoverController),
+);
+
+/**
+ * @swagger
+ * /api/v1/system/failover/reset:
+ *   post:
+ *     tags:
+ *       - System Control
+ *     summary: Reset the manual failover override
+ *     description: Re-enable automatic regional failover logic after a manual override.
+ *     responses:
+ *       '200':
+ *         description: Reset successful
+ *       '500':
+ *         description: Server error
+ */
+router.post(
+  "/failover/reset",
+  systemFailoverController.resetFailover.bind(systemFailoverController),
+);
+
+/**
+ * @swagger
+ * /api/v1/system/failover:
+ *   get:
+ *     tags:
+ *       - System Control
+ *     summary: Get current regional failover status
+ *     description: Retrieve the current active cluster, health state of both regions, and whether a manual override is in effect.
+ *     responses:
+ *       '200':
+ *         description: Status retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: object
+ */
+router.get(
+  "/failover",
+  systemFailoverController.getFailoverStatus.bind(systemFailoverController),
+);
+
+export default router;

--- a/src/services/regionalHealthService.ts
+++ b/src/services/regionalHealthService.ts
@@ -1,0 +1,262 @@
+import axios from "axios";
+
+type FailoverRegion = "PRIMARY" | "SECONDARY";
+
+type RegionStatus = {
+  url: string;
+  healthy: boolean;
+  consecutiveFailures: number;
+  lastCheckedAt: string | null;
+};
+
+const DEFAULT_FAILOVER_THRESHOLD = 3;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 30000;
+const DEFAULT_HEARTBEAT_TIMEOUT_MS = 5000;
+const DEFAULT_HEARTBEAT_PATH = "/health";
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function normalizeHeartbeatPath(path: string): string {
+  if (!path || path.trim().length === 0) {
+    return DEFAULT_HEARTBEAT_PATH;
+  }
+
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function buildHeartbeatUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}${path}`;
+}
+
+export interface RegionalHealthState {
+  activeRegion: FailoverRegion;
+  activeUrl: string;
+  manualOverrideRegion: FailoverRegion | null;
+  primary: RegionStatus;
+  secondary: RegionStatus;
+  failoverThreshold: number;
+  heartbeatIntervalMs: number;
+  heartbeatTimeoutMs: number;
+}
+
+export class RegionalHealthService {
+  private readonly primaryUrl: string;
+  private readonly secondaryUrl: string;
+  private readonly heartbeatPath: string;
+  private readonly heartbeatIntervalMs: number;
+  private readonly heartbeatTimeoutMs: number;
+  private readonly failoverThreshold: number;
+  private activeRegion: FailoverRegion = "PRIMARY";
+  private manualOverrideRegion: FailoverRegion | null = null;
+  private monitoringTimer: NodeJS.Timeout | null = null;
+
+  private status: {
+    primary: RegionStatus;
+    secondary: RegionStatus;
+  };
+
+  constructor() {
+    this.primaryUrl =
+      process.env.PRIMARY_CLUSTER_HEALTH_URL ||
+      process.env.LAGOS_CLUSTER_HEALTH_URL ||
+      "https://lagos-backend.example.com";
+
+    this.secondaryUrl =
+      process.env.SECONDARY_CLUSTER_HEALTH_URL ||
+      process.env.FRANKFURT_CLUSTER_HEALTH_URL ||
+      "https://frankfurt-backend.example.com";
+
+    this.heartbeatPath = normalizeHeartbeatPath(
+      process.env.REGIONAL_HEARTBEAT_PATH || DEFAULT_HEARTBEAT_PATH,
+    );
+    this.heartbeatIntervalMs = parsePositiveInt(
+      process.env.REGIONAL_HEARTBEAT_INTERVAL_MS,
+      DEFAULT_HEARTBEAT_INTERVAL_MS,
+    );
+    this.heartbeatTimeoutMs = parsePositiveInt(
+      process.env.REGIONAL_HEARTBEAT_TIMEOUT_MS,
+      DEFAULT_HEARTBEAT_TIMEOUT_MS,
+    );
+    this.failoverThreshold = parsePositiveInt(
+      process.env.FAILOVER_THRESHOLD,
+      DEFAULT_FAILOVER_THRESHOLD,
+    );
+
+    this.status = {
+      primary: {
+        url: this.primaryUrl,
+        healthy: true,
+        consecutiveFailures: 0,
+        lastCheckedAt: null,
+      },
+      secondary: {
+        url: this.secondaryUrl,
+        healthy: true,
+        consecutiveFailures: 0,
+        lastCheckedAt: null,
+      },
+    };
+  }
+
+  getState(): RegionalHealthState {
+    return {
+      activeRegion: this.activeRegion,
+      activeUrl: this.getActiveUrl(),
+      manualOverrideRegion: this.manualOverrideRegion,
+      primary: { ...this.status.primary },
+      secondary: { ...this.status.secondary },
+      failoverThreshold: this.failoverThreshold,
+      heartbeatIntervalMs: this.heartbeatIntervalMs,
+      heartbeatTimeoutMs: this.heartbeatTimeoutMs,
+    };
+  }
+
+  getActiveUrl(): string {
+    return this.activeRegion === "PRIMARY"
+      ? this.primaryUrl
+      : this.secondaryUrl;
+  }
+
+  getActiveRegion(): FailoverRegion {
+    return this.activeRegion;
+  }
+
+  async startMonitoring(): Promise<void> {
+    if (this.monitoringTimer) {
+      return;
+    }
+
+    await this.performHealthCheck();
+
+    this.monitoringTimer = setInterval(async () => {
+      try {
+        await this.performHealthCheck();
+      } catch (error) {
+        console.error("[RegionalHealthService] Health check failed:", error);
+      }
+    }, this.heartbeatIntervalMs);
+  }
+
+  stopMonitoring(): void {
+    if (this.monitoringTimer) {
+      clearInterval(this.monitoringTimer);
+      this.monitoringTimer = null;
+    }
+  }
+
+  async forceFailover(region: FailoverRegion): Promise<RegionalHealthState> {
+    if (region !== "PRIMARY" && region !== "SECONDARY") {
+      throw new Error("Invalid failover region");
+    }
+
+    this.manualOverrideRegion = region;
+    this.setActiveRegion(region, "manual override");
+    return this.getState();
+  }
+
+  async resetManualOverride(): Promise<RegionalHealthState> {
+    this.manualOverrideRegion = null;
+    return this.getState();
+  }
+
+  private async performHealthCheck(): Promise<void> {
+    const primaryHealthy = await this.pingRegion("PRIMARY");
+    const secondaryHealthy = await this.pingRegion("SECONDARY");
+
+    this.status.primary.healthy = primaryHealthy;
+    this.status.secondary.healthy = secondaryHealthy;
+
+    if (!this.manualOverrideRegion) {
+      this.evaluateAutomaticFailover();
+    }
+  }
+
+  private async pingRegion(region: FailoverRegion): Promise<boolean> {
+    const url = region === "PRIMARY" ? this.primaryUrl : this.secondaryUrl;
+    const heartbeatUrl = buildHeartbeatUrl(url, this.heartbeatPath);
+    const result = {
+      region,
+      healthy: false,
+      timestamp: new Date().toISOString(),
+    };
+
+    try {
+      const response = await axios.get(heartbeatUrl, {
+        timeout: this.heartbeatTimeoutMs,
+      });
+
+      result.healthy = response.status >= 200 && response.status < 400;
+    } catch (error) {
+      result.healthy = false;
+    }
+
+    const statusSlot =
+      region === "PRIMARY" ? this.status.primary : this.status.secondary;
+
+    statusSlot.lastCheckedAt = result.timestamp;
+    statusSlot.consecutiveFailures = result.healthy
+      ? 0
+      : statusSlot.consecutiveFailures + 1;
+
+    return result.healthy;
+  }
+
+  private evaluateAutomaticFailover(): void {
+    const primary = this.status.primary;
+    const secondary = this.status.secondary;
+
+    if (this.activeRegion === "PRIMARY") {
+      if (
+        !primary.healthy &&
+        primary.consecutiveFailures >= this.failoverThreshold &&
+        secondary.healthy
+      ) {
+        this.setActiveRegion("SECONDARY", "automatic failover");
+      }
+    } else {
+      if (primary.healthy && primary.consecutiveFailures === 0) {
+        this.setActiveRegion("PRIMARY", "automatic failback");
+        return;
+      }
+
+      if (
+        !secondary.healthy &&
+        secondary.consecutiveFailures >= this.failoverThreshold &&
+        primary.healthy
+      ) {
+        this.setActiveRegion("PRIMARY", "automatic failback due to secondary outage");
+      }
+    }
+  }
+
+  private setActiveRegion(region: FailoverRegion, reason: string): void {
+    if (this.activeRegion === region) {
+      return;
+    }
+
+    this.activeRegion = region;
+    console.info(
+      `[RegionalHealthService] Active region changed to ${region} (${this.getActiveUrl()}) via ${reason}`,
+    );
+  }
+}
+
+let singleton: RegionalHealthService | null = null;
+
+export function getRegionalHealthService(): RegionalHealthService {
+  if (!singleton) {
+    singleton = new RegionalHealthService();
+  }
+  return singleton;
+}


### PR DESCRIPTION
Closes #202

---

…witching

- Create RegionalHealthService to monitor heartbeat of primary and secondary clusters
- Implement automated failover logic based on configurable FAILOVER_THRESHOLD
- Add systemFailoverController with manual override endpoints
- Register /api/v1/system/failover routes for status checks and manual failover
- Integrate monitoring service into application startup
- Add environment variables for cluster health URLs and failover configuration
- Support automatic failback when primary cluster recovers

Resolves: Regional failover requirement