### PR TITLE
fix: use median for NGN price aggregation

### DIFF
--- a/src/services/marketRate/index.ts
+++ b/src/services/marketRate/index.ts
@@ -4,3 +4,4 @@ export * from "./ghsFetcher";
 export * from "./ngnFetcher";
 export * from "./marketRateService";
 export * from "./middleValuePriceService";
+export * from "./medianPriceService";

--- a/src/services/marketRate/medianPriceService.ts
+++ b/src/services/marketRate/medianPriceService.ts
@@ -1,0 +1,12 @@
+export class MedianPriceService {
+  calculateMedian(values: number[]): number {
+    if (values.length < 3) {
+      throw new Error("At least 3 values are required to calculate median");
+    }
+
+    const sorted = [...values].sort((a, b) => a - b);
+    const middleIndex = Math.floor(sorted.length / 2);
+
+    return sorted[middleIndex] ?? 0;
+  }
+}

--- a/src/services/marketRate/ngnFetcher.ts
+++ b/src/services/marketRate/ngnFetcher.ts
@@ -1,17 +1,9 @@
 import axios from "axios";
 import { OUTGOING_HTTP_TIMEOUT_MS } from "../../utils/httpTimeout.js";
-import {
-  MarketRateFetcher,
-  MarketRate,
-  calculateWeightedAverage,
-  filterOutliers,
-} from "./types";
+import { MarketRateFetcher, MarketRate, filterOutliers } from "./types";
 import { withRetry } from "../../utils/retryUtil.js";
-import {
-  getNGNProviderWeight,
-  type NGNProviderWeightKey,
-} from "../../config/providerWeights.js";
 import { createFetcherLogger } from "../../utils/logger.js";
+import { MedianPriceService } from "./medianPriceService.js";
 
 type CoinGeckoPriceResponse = {
   stellar?: {
@@ -48,7 +40,6 @@ type NGNPriceCandidate = {
   rate: number;
   timestamp: Date;
   source: string;
-  providerKey: NGNProviderWeightKey;
 };
 
 function parseAmount(value: string | undefined): number | null {
@@ -74,6 +65,7 @@ export class NGNRateFetcher implements MarketRateFetcher {
 
   private readonly usdToNgnUrl = "https://open.er-api.com/v6/latest/USD";
   private logger = createFetcherLogger("NGNRate");
+  private medianPriceService = new MedianPriceService();
 
   private vtpassBase(): string {
     return (
@@ -169,7 +161,6 @@ export class NGNRateFetcher implements MarketRateFetcher {
             rate: usd * vt.ngnPerUsd,
             timestamp: ts,
             source: "VTpass variation + CoinGecko (XLM/USD)",
-            providerKey: "vtpassCoinGeckoUsd",
           });
         }
       }
@@ -203,7 +194,6 @@ export class NGNRateFetcher implements MarketRateFetcher {
           rate: stellarPrice.ngn,
           timestamp: lastUpdatedAt,
           source: "CoinGecko (direct NGN)",
-          providerKey: "coinGeckoDirectNgn",
         });
       }
     } catch (error) {
@@ -257,7 +247,6 @@ export class NGNRateFetcher implements MarketRateFetcher {
             timestamp:
               fxTimestamp > lastUpdatedAt ? fxTimestamp : lastUpdatedAt,
             source: "CoinGecko + ExchangeRate API (USD->NGN)",
-            providerKey: "coinGeckoExchangeRateUsdNgn",
           });
         }
       }
@@ -275,31 +264,41 @@ export class NGNRateFetcher implements MarketRateFetcher {
       throw error;
     }
 
-    const filteredRateValues = filterOutliers(
-      prices.map((p) => p.rate).filter((rate) => rate > 0),
-    );
+    const rateValues = prices
+      .map((price) => price.rate)
+      .filter((rate) => Number.isFinite(rate) && rate > 0);
+    const filteredRateValues = filterOutliers(rateValues);
     const filteredPrices = prices.filter((price) =>
       filteredRateValues.includes(price.rate),
     );
-    const pricesToUse = filteredPrices.length > 0 ? filteredPrices : prices;
+    const pricesToUse =
+      filteredPrices.length >= 3 ? filteredPrices : prices;
 
-    const mostRecentTimestamp = prices.reduce(
+    if (pricesToUse.length < 3) {
+      const error = new Error(
+        `Need at least 3 price sources for median calculation, got ${pricesToUse.length}`,
+      );
+      this.logger.fetcherError(error.message, {
+        attemptedSources: 3,
+        pricesLength: pricesToUse.length,
+      });
+      throw error;
+    }
+
+    const mostRecentTimestamp = pricesToUse.reduce(
       (latest, p) => (p.timestamp > latest ? p.timestamp : latest),
-      prices[0]?.timestamp ?? new Date(),
+      pricesToUse[0]?.timestamp ?? new Date(),
     );
 
-    const weightedRate = calculateWeightedAverage(
-      pricesToUse.map((price) => ({
-        value: price.rate,
-        weight: getNGNProviderWeight(price.providerKey),
-      })),
+    const medianRate = this.medianPriceService.calculateMedian(
+      pricesToUse.map((price) => price.rate),
     );
 
     return {
       currency: "NGN",
-      rate: weightedRate,
+      rate: medianRate,
       timestamp: mostRecentTimestamp,
-      source: `Weighted average of ${pricesToUse.length} sources (outliers filtered)`,
+      source: `Median of ${pricesToUse.length} sources`,
     };
   }
 

--- a/test/ngnFetcher.test.ts
+++ b/test/ngnFetcher.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import axios from "axios";
 import { NGNRateFetcher } from "../src/services/marketRate/ngnFetcher";
-import { NGN_PROVIDER_WEIGHTS } from "../src/config/providerWeights.js";
 
 async function run() {
   const originalGet = axios.get;
@@ -67,19 +66,13 @@ async function run() {
     }) as typeof axios.get;
 
     const rate = await fetcher.fetchRate();
-    const expectedRate =
-      (300 * NGN_PROVIDER_WEIGHTS.vtpassCoinGeckoUsd +
-        300 * NGN_PROVIDER_WEIGHTS.coinGeckoDirectNgn +
-        1500 * NGN_PROVIDER_WEIGHTS.coinGeckoExchangeRateUsdNgn) /
-      (NGN_PROVIDER_WEIGHTS.vtpassCoinGeckoUsd +
-        NGN_PROVIDER_WEIGHTS.coinGeckoDirectNgn +
-        NGN_PROVIDER_WEIGHTS.coinGeckoExchangeRateUsdNgn);
+    const expectedRate = 300;
 
     assert.equal(rate.currency, "NGN");
     assert.equal(rate.rate, expectedRate);
     assert.equal(
       rate.source,
-      "Weighted average of 3 sources (outliers filtered)",
+      "Median of 3 sources",
     );
   } finally {
     axios.get = originalGet;


### PR DESCRIPTION

### Summary

NGN rate aggregation used a weighted average across providers, making the
final rate susceptible to skew from outlier values. This PR replaces that
approach with a median-based calculation, eliminating single-provider
influence on the output rate.

---

### Root Cause

Weighted averaging does not bound the influence of any individual provider.
A single outlier feed — whether due to stale data, a provider incident, or
manipulation — could materially shift the aggregated NGN rate even when other
providers were in agreement.

---

### What Changed

**1. Median service**
Added a small, focused median calculation service to handle middle-value
selection across a sorted provider set.

**2. NGN aggregation updated**
Replaced the weighted average with a call to the median service. Aggregation
now requires a minimum of three sources before producing a result, ensuring
the middle value is always well-defined.
Closes #228