### PR TITLE
feat: K-sortable KSUID generator for log entry IDs

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,7 +139,7 @@ model MultiSigSignature {
 
 // Error log table for tracking provider/fetcher failures
 model ErrorLog {
-  id           Int      @id @default(autoincrement())
+  id           String   @id  // K-sortable KSUID (26-char Crockford Base32)
   providerName String   // e.g., "CoinGecko", "KESRateFetcher"
   errorMessage String?
   occurredAt   DateTime
@@ -324,7 +324,7 @@ model PendingSignature {
 // Audit Log Table for System Actions
 // Comprehensive audit trail for all sensitive system operations
 model AuditLog {
-  id                    Int       @id @default(autoincrement())
+  id                    String    @id  // K-sortable KSUID (26-char Crockford Base32)
   eventType             String    @db.VarChar(50)    // e.g., "CONSENSUS_INITIATED", "CONSENSUS_APPROVED", "ACTION_EXECUTED"
   actionType            String?   @db.VarChar(50)    // The type of action being audited (e.g., "HALT", "UPGRADE")
   relatedId             Int?                         // ID of related record (e.g., PendingConsensus.id)

--- a/src/services/errorTracker.ts
+++ b/src/services/errorTracker.ts
@@ -1,4 +1,5 @@
 import prisma from "../lib/prisma";
+import { generateKsuid } from "../utils/ksuid.js";
 
 type FailureRecord = {
   count: number;
@@ -51,6 +52,7 @@ export class ErrorTracker {
       ) {
         await clientAny.errorLog.create({
           data: {
+            id: generateKsuid(),
             providerName: serviceKey,
             errorMessage:
               errorDetails instanceof Error

--- a/src/services/userAuditService.ts
+++ b/src/services/userAuditService.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../lib/prisma.js";
+import { generateKsuid } from "../utils/ksuid.js";
 
 export enum UserAuditEventType {
   USER_LOGIN_SUCCESS = "USER_LOGIN_SUCCESS",
@@ -25,10 +26,21 @@ export interface AuditContext {
 }
 
 export async function logUserAccessEvent(ctx: AuditContext): Promise<void> {
-  const { userId, actorId, ipAddress, userAgent, resourceType, resourceId, action, before, after } = ctx;
+  const {
+    userId,
+    actorId,
+    ipAddress,
+    userAgent,
+    resourceType,
+    resourceId,
+    action,
+    before,
+    after,
+  } = ctx;
 
   await prisma.auditLog.create({
     data: {
+      id: generateKsuid(),
       eventType: action,
       actorPublicKey: userId ? `user:${userId}` : "system",
       actorName: userId ? `user:${userId}` : "system",
@@ -77,6 +89,7 @@ export async function logLoginFailed(
 ): Promise<void> {
   await prisma.auditLog.create({
     data: {
+      id: generateKsuid(),
       eventType: UserAuditEventType.USER_LOGIN_FAILED,
       actorPublicKey: `email:${email}`,
       actorName: `email:${email}`,

--- a/src/utils/ksuid.ts
+++ b/src/utils/ksuid.ts
@@ -1,0 +1,82 @@
+/**
+ * K-sortable unique ID generator (ULID-compatible format).
+ *
+ * Structure: 48-bit millisecond timestamp + 80-bit cryptographic random = 128 bits
+ * Encoding:  Crockford Base32 → 26 uppercase characters
+ *
+ * Properties:
+ *  - Lexicographically sortable by creation time
+ *  - Monotonic within the same millisecond (random component incremented)
+ *  - Cryptographically random suffix — looks sophisticated in dashboards
+ *  - No external dependencies (uses Node.js built-in `crypto`)
+ *
+ * Example: 01JVKQ3R8FXNM4P7T2WBHD6YCE
+ */
+
+import { randomBytes } from "crypto";
+
+// Crockford Base32 alphabet (no I, L, O, U to avoid visual ambiguity)
+const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const ENCODING_LEN = ENCODING.length;
+const TIME_LEN = 10; // chars for 48-bit timestamp
+const RANDOM_LEN = 16; // chars for 80-bit random
+
+// Monotonicity guard: if two IDs are generated in the same ms, increment random
+let lastMs = -1;
+let lastRandom = new Uint8Array(10);
+
+function encodeTime(ms: number): string {
+  let t = ms;
+  let result = "";
+  for (let i = TIME_LEN - 1; i >= 0; i--) {
+    result = (ENCODING[t % ENCODING_LEN] ?? "0") + result;
+    t = Math.floor(t / ENCODING_LEN);
+  }
+  return result;
+}
+
+function encodeRandom(bytes: Uint8Array): string {
+  // Treat the 10 bytes as a big-endian 80-bit integer, encode in base32
+  let result = "";
+  // We need 16 base32 chars from 10 bytes (80 bits → 16 × 5 bits)
+  // Pack into a BigInt for clean extraction
+  let n = BigInt(0);
+  for (const b of bytes) {
+    n = (n << BigInt(8)) | BigInt(b);
+  }
+  for (let i = RANDOM_LEN - 1; i >= 0; i--) {
+    result = (ENCODING[Number(n % BigInt(ENCODING_LEN))] ?? "0") + result;
+    n = n / BigInt(ENCODING_LEN);
+  }
+  return result;
+}
+
+function incrementRandom(bytes: Uint8Array): Uint8Array {
+  const next = new Uint8Array(bytes);
+  for (let i = next.length - 1; i >= 0; i--) {
+    if (next[i]! < 255) {
+      next[i]!++;
+      return next;
+    }
+    next[i] = 0;
+  }
+  // Overflow — all bytes were 0xFF; wrap around (extremely unlikely)
+  return next;
+}
+
+/**
+ * Generate a K-sortable unique ID.
+ * Thread-safe within a single Node.js event loop tick.
+ */
+export function generateKsuid(): string {
+  const ms = Date.now();
+
+  if (ms === lastMs) {
+    lastRandom = incrementRandom(lastRandom);
+  } else {
+    lastMs = ms;
+    lastRandom = new Uint8Array(randomBytes(10));
+  }
+
+  return encodeTime(ms) + encodeRandom(lastRandom);
+}

--- a/test/ksuid.jest.test.ts
+++ b/test/ksuid.jest.test.ts
@@ -1,0 +1,42 @@
+import { generateKsuid } from "../src/utils/ksuid";
+
+describe("generateKsuid", () => {
+  it("produces a 26-character string", () => {
+    expect(generateKsuid()).toHaveLength(26);
+  });
+
+  it("uses only Crockford Base32 characters (uppercase, no I/L/O/U)", () => {
+    const VALID = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+    for (let i = 0; i < 100; i++) {
+      expect(generateKsuid()).toMatch(VALID);
+    }
+  });
+
+  it("generates unique IDs", () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => generateKsuid()));
+    expect(ids.size).toBe(1000);
+  });
+
+  it("is lexicographically sortable by creation time", () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      ids.push(generateKsuid());
+    }
+    const sorted = [...ids].sort();
+    expect(sorted).toEqual(ids);
+  });
+
+  it("is monotonic within the same millisecond", () => {
+    // Capture a burst of IDs that are very likely to land in the same ms
+    // (generating 50 in a tight loop virtually guarantees same-ms collisions)
+    const ids: string[] = Array.from({ length: 50 }, () => generateKsuid());
+
+    // All IDs with the same time prefix must be strictly increasing
+    for (let i = 1; i < ids.length; i++) {
+      if (ids[i - 1]!.slice(0, 10) === ids[i]!.slice(0, 10)) {
+        // Same millisecond — random suffix must be strictly greater
+        expect(ids[i]! > ids[i - 1]!).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #263

---

## Summary

Replaces predictable integer auto-increment IDs on `AuditLog` and `ErrorLog` with **K-sortable unique IDs** (ULID-style) that look cryptographic in the admin dashboard.

## Changes

- **`src/utils/ksuid.ts`** — zero-dependency generator using Node `crypto`
  - 26-char Crockford Base32 encoding
  - 48-bit millisecond timestamp + 80-bit cryptographic random = 128 bits
  - Monotonic within the same millisecond (random component incremented, not re-rolled)
  - Example: `01JVKQ3R8FXNM4P7T2WBHD6YCE`
- **`prisma/schema.prisma`** — `AuditLog.id` and `ErrorLog.id` changed from `Int @id @default(autoincrement())` → `String @id`
- **`src/services/errorTracker.ts`** — passes `id: generateKsuid()` on `ErrorLog.create`
- **`src/services/userAuditService.ts`** — passes `id: generateKsuid()` on both `AuditLog.create` calls

## Testing

```
PASS test/ksuid.jest.test.ts
  ✓ produces a 26-character string
  ✓ uses only Crockford Base32 characters (uppercase, no I/L/O/U)
  ✓ generates unique IDs
  ✓ is lexicographically sortable by creation time
  ✓ is monotonic within the same millisecond
```

## Migration note

Run the migration SQL manually (file is gitignored per project convention):
```sql
ALTER TABLE "AuditLog" ALTER COLUMN "id" DROP DEFAULT;
ALTER TABLE "AuditLog" ALTER COLUMN "id" TYPE TEXT USING "id"::TEXT;
ALTER TABLE "ErrorLog" ALTER COLUMN "id" DROP DEFAULT;
ALTER TABLE "ErrorLog" ALTER COLUMN "id" TYPE TEXT USING "id"::TEXT;
DROP SEQUENCE IF EXISTS "AuditLog_id_seq";
DROP SEQUENCE IF EXISTS "ErrorLog_id_seq";
```