### PR TITLE
Fix: enforce integer casting for relayer latencyDiffMs before DB write

### DIFF
--- a/src/middleware/latencyGuardMiddleware.ts
+++ b/src/middleware/latencyGuardMiddleware.ts
@@ -141,7 +141,7 @@ async function logLatencyViolation(
         eventType,
         payloadTimestamp: payloadTimestamp ? new Date(payloadTimestamp) : null,
         receivedAt: new Date(),
-        latencyDiffMs,
+        latencyDiffMs: latencyDiffMs !== null ? Math.round(latencyDiffMs) : null,
         thresholdMs,
         details: JSON.stringify(details),
         resolved: false,

--- a/src/middleware/latencyGuardMiddleware.ts
+++ b/src/middleware/latencyGuardMiddleware.ts
@@ -90,7 +90,7 @@ export const latencyValidationMiddleware = async (
         code: "LATENCY_VIOLATION",
         details: {
           payloadTimestamp,
-          latencyDiffMs: latencyDiff,
+          latencyDiffMs: Math.round(latencyDiff),
           thresholdMs: maxLatencyMs,
         },
       });


### PR DESCRIPTION
Closes #309

Applied Math.round() casting to latencyDiffMs before DB write and in API response to fix float type-mismatch warnings on the front end dashboard.