### PR TITLE
feat: implement new centralized error response schema

### DIFF
--- a/src/lib/apiError.ts
+++ b/src/lib/apiError.ts
@@ -11,9 +11,11 @@ export const WIKI_BASE_URL = (
 
 export interface ApiErrorPayload {
   success: false;
-  error: string;
-  errorCode: string;
-  helpLink: string;
+  error: {
+    code: string;
+    message: string;
+    timestamp: string;
+  };
 }
 
 /** Default human-readable messages for stable error codes. */
@@ -73,9 +75,11 @@ export function apiErrorPayload(
 
   return {
     success: false,
-    error: resolvedMessage,
-    errorCode,
-    helpLink: buildHelpLink(errorCode),
+    error: {
+      code: errorCode,
+      message: resolvedMessage,
+      timestamp: new Date().toISOString(),
+    },
   };
 }
 

--- a/test/apiError.test.ts
+++ b/test/apiError.test.ts
@@ -11,15 +11,16 @@ test("buildHelpLink points at wiki Errors slug", () => {
   assert.equal(link, `${WIKI_BASE_URL}/Errors/MISSING_API_KEY`);
 });
 
-test("apiErrorPayload includes errorCode and helpLink", () => {
+test("apiErrorPayload uses new schema { success: false, error: { code, message, timestamp } }", () => {
   const body = apiErrorPayload("VALIDATION_ERROR", "currency is required");
   assert.equal(body.success, false);
-  assert.equal(body.errorCode, "VALIDATION_ERROR");
-  assert.equal(body.error, "currency is required");
-  assert.ok(body.helpLink.includes("VALIDATION_ERROR"));
+  assert.equal(body.error.code, "VALIDATION_ERROR");
+  assert.equal(body.error.message, "currency is required");
+  assert.ok(body.error.timestamp, "should include timestamp");
+  assert.ok(new Date(body.error.timestamp) instanceof Date);
 });
 
 test("apiErrorPayload falls back to catalog message", () => {
   const body = apiErrorPayload("NOT_FOUND");
-  assert.equal(body.error, "The requested resource was not found.");
+  assert.equal(body.error.message, "The requested resource was not found.");
 });


### PR DESCRIPTION
Closes #287

---

- Update src/lib/apiError.ts to use strict schema { success: false, error: { code, message, timestamp } }
- Update test/apiError.test.ts to validate new error format