### PR TITLE
fix: enforce int cast on timestamps, strip asset identifiers, and add warning on unmapped asset pairs

### DIFF
--- a/src/database/models.py
+++ b/src/database/models.py
@@ -1,0 +1,10 @@
+import sqlite3
+from datetime import datetime
+
+def update_heartbeat(db_connection, asset_id):
+    epoch_ms = datetime.now().timestamp() * 1000
+    db_connection.execute(
+        "UPDATE heartbeats SET last_seen = ? WHERE asset_id = ?",
+        (int(epoch_ms), asset_id)
+    )
+    db_connection.commit()

--- a/src/ingestion/parsers.py
+++ b/src/ingestion/parsers.py
@@ -1,0 +1,9 @@
+from typing import Any
+from utils.signature import validate_signature
+
+def parse_asset(asset_id: str, transaction_hash: str):
+    validate_signature(asset_id.strip())
+    process_transaction(transaction_hash.strip())
+
+def process_transaction(tx_hash: str):
+    pass

--- a/src/network/router.py
+++ b/src/network/router.py
@@ -1,0 +1,15 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+def validate_asset_pair(asset_code: str):
+    ASSET_MAP = {
+        "USD": "US Dollar",
+        "EUR": "Euro",
+        "GBP": "British Pound"
+    }
+    try:
+        result = ASSET_MAP[asset_code]
+        return result
+    except Exception:
+        logger.warning(f"Unmapped asset code encountered: {asset_code}")


### PR DESCRIPTION
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">This PR addresses three bug fixes across the ingestion, database, and routing layers to improve type safety, input sanitization, and error observability.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">#325 &amp; #326 — Telemetry-Sync: Enforce Clean Unix Timestamp Int Cast (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/database/models.py</code>)</h4>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Problem:</strong> The heartbeat checkpoint update handler occasionally receives epoch millisecond timestamps as floats, causing type warnings during high-volume database index sweeps.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Fix:</strong> Wrapped the dynamic epoch millisecond variable in an explicit <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">int()</code> cast before it is passed to the database update query.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">#324 — Stream-Sanitization: Strip Leading Whitespace on Ingested Feeds (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/ingestion/parsers.py</code>)</h4>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Problem:</strong> Certain regional currency API sources return asset identifiers and transaction hashes with leading whitespace or hidden tab characters, causing downstream cryptographic signature validation to incorrectly reject valid payloads.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Fix:</strong> Applied <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">.strip()</code> to all raw asset identifier variables before they are passed to the signature evaluation block.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">#327 — Logic-Safety: Replace Empty Exception Pass with Warning Log (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/network/router.py</code>)</h4>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Problem:</strong> When an asset pair cannot be matched in the validator parsing block, the exception is silently swallowed by a bare <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pass</code> statement, making post-mortem debugging significantly harder.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Fix:</strong> Replaced the empty <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pass</code> with a <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">logger.warning()</code> call that explicitly logs the unmapped asset code for traceability.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">Files Changed</h4>
<div class="overflow-x-auto w-full px-2 mb-6">
File | Change
-- | --
src/database/models.py | Wrapped epoch timestamp in int() cast
src/ingestion/parsers.py | Applied .strip() to raw asset identifier inputs
src/network/router.py | Replaced empty pass with logger.warning()

</div><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">This PR addresses three bug fixes across the ingestion, database, and routing layers to improve type safety, input sanitization, and error observability.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">#325 &amp; #326 — Telemetry-Sync: Enforce Clean Unix Timestamp Int Cast (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/database/models.py</code>)</h4>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Problem:</strong> The heartbeat checkpoint update handler occasionally receives epoch millisecond timestamps as floats, causing type warnings during high-volume database index sweeps.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Fix:</strong> Wrapped the dynamic epoch millisecond variable in an explicit <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">int()</code> cast before it is passed to the database update query.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">#324 — Stream-Sanitization: Strip Leading Whitespace on Ingested Feeds (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/ingestion/parsers.py</code>)</h4>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Problem:</strong> Certain regional currency API sources return asset identifiers and transaction hashes with leading whitespace or hidden tab characters, causing downstream cryptographic signature validation to incorrectly reject valid payloads.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Fix:</strong> Applied <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">.strip()</code> to all raw asset identifier variables before they are passed to the signature evaluation block.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">#327 — Logic-Safety: Replace Empty Exception Pass with Warning Log (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/network/router.py</code>)</h4>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Problem:</strong> When an asset pair cannot be matched in the validator parsing block, the exception is silently swallowed by a bare <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pass</code> statement, making post-mortem debugging significantly harder.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Fix:</strong> Replaced the empty <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pass</code> with a <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">logger.warning()</code> call that explicitly logs the unmapped asset code for traceability.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">Files Changed</h4>
<div class="overflow-x-auto w-full px-2 mb-6">
File | Change
-- | --
src/database/models.py | Wrapped epoch timestamp in int() cast
src/ingestion/parsers.py | Applied .strip() to raw asset identifier inputs
src/network/router.py | Replaced empty pass with logger.warning()

</div>

closes #326 
closes #324 
closes #325 
closes #327 