### PR TITLE
fix(#292): Empty state payload handling for analytics routes

### DIFF
--- a/src/controllers/analyticsController.ts
+++ b/src/controllers/analyticsController.ts
@@ -180,7 +180,7 @@ export async function getOhlcCandles(
     // ------------------------------------------------------------------
     // 2. Query OhlcCandle table
     // ------------------------------------------------------------------
-    const candles = await prisma.ohlcCandle.findMany({
+    const candles = (await prisma.ohlcCandle.findMany({
       where: {
         currency: upperCurrency,
         granularity: upperGranularity,
@@ -200,7 +200,7 @@ export async function getOhlcCandles(
         close: true,
         count: true,
       },
-    });
+    })) || [];
 
     // ------------------------------------------------------------------
     // 3. Serialise (Decimal → string for wire safety)

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -47,7 +47,7 @@ router.get(
   }),
   async (req, res) => {
   try {
-    const assets = await prisma.currency.findMany({
+    const assets = (await prisma.currency.findMany({
       where: { isActive: true },
       select: {
         code: true,
@@ -55,7 +55,7 @@ router.get(
         symbol: true,
       },
       orderBy: { code: "asc" },
-    });
+    })) || [];
 
     res.json({
       success: true,

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -17,15 +17,15 @@ const router = Router();
 router.get("/relayers", async (req: Request, res: Response) => {
   try {
     // Get all unique signers/relayers
-    const signers = await prisma.multiSigSignature.groupBy({
+    const signers = (await prisma.multiSigSignature.groupBy({
       by: ["signerPublicKey", "signerName"],
       _count: {
         id: true,
       },
-    });
+    })) || [];
 
     // Get all submitted multi-sig prices
-    const submittedPrices = await prisma.multiSigPrice.findMany({
+    const submittedPrices = (await prisma.multiSigPrice.findMany({
       where: {
         status: "APPROVED",
         submittedAt: { not: null },
@@ -38,7 +38,7 @@ router.get("/relayers", async (req: Request, res: Response) => {
           },
         },
       },
-    });
+    })) || [];
 
     // Calculate statistics for each relayer
     const relayerStats = await Promise.all(
@@ -51,7 +51,7 @@ router.get("/relayers", async (req: Request, res: Response) => {
           const { signerPublicKey, signerName, _count } = signer;
 
           // Get all signatures by this relayer
-          const signatures = await prisma.multiSigSignature.findMany({
+          const signatures = (await prisma.multiSigSignature.findMany({
             where: { signerPublicKey },
             include: {
               multiSigPrice: {
@@ -65,7 +65,7 @@ router.get("/relayers", async (req: Request, res: Response) => {
             orderBy: {
               signedAt: "desc",
             },
-          });
+          })) || [];
 
           // Calculate successful pushes (prices that were submitted to Stellar)
           const successfulPushes = signatures.filter(
@@ -198,7 +198,7 @@ router.get(
       });
 
       // Get provider requests for the day (from reputation service)
-      const providerStats = await prisma.providerReputation.findMany({
+      const providerStats = (await prisma.providerReputation.findMany({
         select: {
           providerName: true,
           totalRequests: true,
@@ -207,7 +207,7 @@ router.get(
           lastSuccess: true,
           lastFailure: true,
         },
-      });
+      })) || [];
 
       // Calculate total requests (this is cumulative, not daily)
       const totalApiRequests = providerStats.reduce(
@@ -224,7 +224,7 @@ router.get(
       );
 
       // Get unique currencies that had activity
-      const activeCurrencies = await prisma.priceHistory.findMany({
+      const activeCurrencies = (await prisma.priceHistory.findMany({
         where: {
           timestamp: {
             gte: startOfDay,
@@ -235,10 +235,10 @@ router.get(
           currency: true,
         },
         distinct: ["currency"],
-      });
+      })) || [];
 
       // Get unique data sources for the day
-      const activeSources = await prisma.priceHistory.findMany({
+      const activeSources = (await prisma.priceHistory.findMany({
         where: {
           timestamp: {
             gte: startOfDay,
@@ -249,7 +249,7 @@ router.get(
           source: true,
         },
         distinct: ["source"],
-      });
+      })) || [];
 
       const volumeStats = {
         date: targetDate.toISOString().split("T")[0],

--- a/src/services/intelligenceService.ts
+++ b/src/services/intelligenceService.ts
@@ -140,11 +140,11 @@ export class IntelligenceService {
       windowEnd.getTime() - HOURLY_VOLATILITY_WINDOW_MINUTES * 60 * 1000,
     );
 
-    const activeCurrencies = await this.db.currency.findMany({
+    const activeCurrencies = (await this.db.currency.findMany({
       where: { isActive: true },
       select: { code: true },
       orderBy: { code: "asc" },
-    });
+    })) || [];
 
     const currencyCodes = activeCurrencies.map((currency) => currency.code);
 
@@ -158,7 +158,7 @@ export class IntelligenceService {
       };
     }
 
-    const recentPrices = await this.db.priceHistory.findMany({
+    const recentPrices = (await this.db.priceHistory.findMany({
       where: {
         currency: {
           in: currencyCodes,
@@ -174,7 +174,7 @@ export class IntelligenceService {
         rate: true,
         timestamp: true,
       },
-    });
+    })) || [];
 
     const groupedRates = new Map<
       string,


### PR DESCRIPTION
- Wrap database aggregation methods with fallback arrays (result || [])
- Ensures API returns 200 OK with empty array instead of TypeError crash
- Fixes: analyticsController ohlcCandle queries
- Fixes: stats routes for relayers, volume, and provider endpoints
- Fixes: assets route currency queries
- Fixes: intelligence service currency and price history queries
- Returns clean empty payload when no historical data exists


Closes #292