### PR TITLE
Add sliding window analytics buffer with fixed 100-entry deque

### DIFF
--- a/src/analytics/__init__.py
+++ b/src/analytics/__init__.py
@@ -13,6 +13,7 @@ from .checked_math import (
     validate_metric_value,
 )
 from .ema import RollingEMA, update_ema, ema_sequence, smoothing_factor, progressive_smoothing_factor
+from .window import SlidingWindowBuffer
 
 __all__ = [
     "BoundaryViolationError",
@@ -32,4 +33,5 @@ __all__ = [
     "ema_sequence",
     "smoothing_factor",
     "progressive_smoothing_factor",
+    "SlidingWindowBuffer",
 ]

--- a/src/analytics/window.py
+++ b/src/analytics/window.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Deque, Iterable, Iterator
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class SlidingWindowBuffer(Generic[T]):
+    """Fixed-size rolling buffer for near-term analytics events.
+
+    Uses a deque with a bounded max length so older records fall out
+    automatically when the buffer exceeds capacity.
+    """
+
+    MAX_ENTRIES: int = 100
+
+    def __init__(self, maxlen: int = MAX_ENTRIES) -> None:
+        self._buffer: Deque[T] = deque(maxlen=maxlen)
+
+    def append(self, item: T) -> None:
+        self._buffer.append(item)
+
+    def extend(self, items: Iterable[T]) -> None:
+        self._buffer.extend(items)
+
+    def clear(self) -> None:
+        self._buffer.clear()
+
+    def __len__(self) -> int:
+        return len(self._buffer)
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self._buffer)
+
+    def to_list(self) -> list[T]:
+        return list(self._buffer)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from analytics.window import SlidingWindowBuffer
+
+
+def test_sliding_window_buffer_retains_most_recent_entries() -> None:
+    buffer = SlidingWindowBuffer[int]()
+    buffer.extend(range(120))
+
+    assert len(buffer) == 100
+    assert buffer.to_list() == list(range(20, 120))
+
+
+def test_sliding_window_buffer_appends_and_discards_oldest() -> None:
+    buffer = SlidingWindowBuffer[int]()
+    for i in range(100):
+        buffer.append(i)
+
+    assert len(buffer) == 100
+    assert buffer.to_list()[0] == 0
+
+    buffer.append(100)
+    assert len(buffer) == 100
+    assert buffer.to_list()[0] == 1
+    assert buffer.to_list()[-1] == 100


### PR DESCRIPTION
## PR Description

### Summary
Implemented a fixed-size rolling analytics buffer to reduce in-memory log retention and prevent full-day event accumulation.

### What changed
- Added window.py
  - Introduced `SlidingWindowBuffer`
  - Uses `collections.deque` with a configurable max length
  - Defaults to keeping only the most recent `100` entries
  - Older records drop naturally as new entries arrive
- Exported `SlidingWindowBuffer` from __init__.py
- Added coverage in test_window.py
  - Verifies buffer capacity limits to 100 entries
  - Confirms oldest values are discarded when overfilled
  -   - issue:  -
  -   - close #356   -  

### Branch
- `storage-buffer-sliding-window-array-metrics-filters`

### Notes
- No existing analytics logic was modified beyond package export
- This adds a reusable in-memory sliding window structure for near-term analytics metrics filtering
- - 
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 