### PR TITLE
feat: implement role matrix permission isolation #378

### DIFF
--- a/src/middleware/jwtMiddleware.ts
+++ b/src/middleware/jwtMiddleware.ts
@@ -8,6 +8,8 @@ declare global {
         userId: number;
         email: string;
         role: string;
+        group?: string;        // Added for future group isolation
+        permissions?: string[]; // Added for fine-grained control
       };
       sessionId?: number;
     }
@@ -50,10 +52,13 @@ export const jwtMiddleware = (
     return next();
   }
 
+  // Updated user object with role (already present) + optional fields
   (req as Request & { user: any }).user = {
     userId: payload.userId,
     email: payload.email,
-    role: payload.role,
+    role: payload.role || 'OBSERVER',           // Default to OBSERVER if missing
+    group: payload.group,
+    permissions: payload.permissions,
   };
 
   next();

--- a/src/middleware/roleMatrixMiddleware.ts
+++ b/src/middleware/roleMatrixMiddleware.ts
@@ -1,0 +1,74 @@
+import { Request, Response, NextFunction } from 'express';
+import { Role, Permission } from '../types/roles.js';
+
+export interface AuthRequest extends Request {
+  user?: {
+    role: Role;
+    group?: string;
+    permissions?: Permission[];
+  };
+}
+
+// Tier-based Role Matrix
+const ROLE_MATRIX: Record<Role, Permission[]> = {
+  OBSERVER: ['read:prices', 'read:market'],
+  OPERATOR: ['read:prices', 'read:market', 'write:oracle', 'read:config'],
+  ADMIN: ['*'], // Full access
+  SUPER_ADMIN: ['*'],
+};
+
+const SENSITIVE_PATHS = [
+  '/admin',
+  '/config',
+  '/network',
+  '/soroban',
+  '/keys',
+];
+
+/**
+ * Strict Group Permission Isolation Middleware
+ */
+export const enforceRoleMatrix = (requiredPermission?: Permission) => {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    const user = req.user;
+
+    if (!user) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+        message: 'Valid authentication required'
+      });
+    }
+
+    // Early blocking for sensitive paths
+    const isSensitivePath = SENSITIVE_PATHS.some(path => 
+      req.path.toLowerCase().startsWith(path)
+    );
+
+    if (isSensitivePath && user.role === 'OBSERVER') {
+      return res.status(403).json({
+        error: 'Access Denied',
+        message: 'Observer keys cannot access administrative or configuration endpoints',
+        code: 'ROLE_ISOLATION_VIOLATION'
+      });
+    }
+
+    // Permission check
+    const userPermissions = ROLE_MATRIX[user.role] || [];
+
+    if (requiredPermission && 
+        !userPermissions.includes(requiredPermission) && 
+        !userPermissions.includes('*')) {
+      return res.status(403).json({
+        error: 'Insufficient Permissions',
+        message: `Role ${user.role} lacks permission: ${requiredPermission}`,
+        code: 'INSUFFICIENT_PERMISSIONS'
+      });
+    }
+
+    next();
+  };
+};
+
+// Convenience middleware
+export const requireAdmin = enforceRoleMatrix();
+export const requireOperator = enforceRoleMatrix('write:oracle');

--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -1,0 +1,9 @@
+export type Role = 'OBSERVER' | 'OPERATOR' | 'ADMIN' | 'SUPER_ADMIN';
+
+export type Permission = 
+  | 'read:prices' 
+  | 'read:market' 
+  | 'write:oracle' 
+  | 'read:config' 
+  | 'write:config'
+  | '*';


### PR DESCRIPTION
#378 🔒 Role-Matrix | Enforcing Strict Group Permission Isolation

## What?
Implemented strict Role-Matrix permission middleware to block OBSERVER keys from accessing admin/config endpoints.

## Changes
- Created `src/middleware/roleMatrixMiddleware.ts`
- Updated `src/middleware/jwtMiddleware.ts` (minimal change)
- Added proper role extraction and early access denial

## Security Improvement
Observer roles can no longer access sensitive paths (`/admin`, `/config`, `/network`, etc.)

Closes #378 