### PR TITLE
feat: #401 background connection keep-alive for relational sink

### DIFF
--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Database Connection Keep-Alive
+==============================
+Maintains long-lived relational connections during quiet, low-volume market
+windows.
+ 
+Serverless / autoscaled Postgres sinks (and intermediary poolers such as
+PgBouncer) frequently drop idle TCP connections after a short timeout. When the
+next price record arrives, the first write then stalls waiting for a fresh TCP
+handshake and re-authentication. This module runs a low-overhead background
+heartbeat (``SELECT 1;``) on a fixed interval to keep the channel warm so the
+write path never pays the reconnect cost.
+ 
+The keep-alive is connection-agnostic: it accepts any DB-API 2.0 connection
+exposing ``cursor()``. It is meaningful for networked backends (e.g. PostgreSQL
+via ``psycopg2``); for a local ``sqlite3`` connection there is no socket to keep
+open, so the ping is harmless but inert.
+ 
+Usage:
+    conn = psycopg2.connect(DATABASE_URL)
+    keepalive = ConnectionKeepAlive(conn, interval=30.0)
+    keepalive.start()
+    ...
+    keepalive.stop()   # stops the background thread
+"""
+ 
+import logging
+import threading
+from typing import Any, Optional
+ 
+logger = logging.getLogger(__name__)
+ 
+# Default heartbeat cadence in seconds. Idle-connection timeouts on serverless
+# Postgres / PgBouncer are commonly 60-300s, so a 30s ping keeps the channel
+# warm with comfortable margin.
+DEFAULT_PING_INTERVAL: float = 30.0
+HEARTBEAT_QUERY: str = "SELECT 1;"
+ 
+ 
+class ConnectionKeepAlive:
+    """Background heartbeat that keeps a relational connection channel alive.
+ 
+    A daemon thread wakes every ``interval`` seconds and issues a lightweight
+    ``SELECT 1;`` against the supplied connection. The thread is interruptible:
+    ``stop()`` signals it via an :class:`threading.Event`, so shutdown does not
+    wait out the full interval.
+    """
+ 
+    def __init__(
+        self,
+        connection: Any,
+        interval: float = DEFAULT_PING_INTERVAL,
+        query: str = HEARTBEAT_QUERY,
+    ) -> None:
+        if connection is None:
+            raise ValueError("connection must not be None")
+        if interval <= 0:
+            raise ValueError("interval must be a positive number of seconds")
+ 
+        self._conn = connection
+        self._interval = interval
+        self._query = query
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+ 
+    @property
+    def is_running(self) -> bool:
+        """True while the background heartbeat thread is alive."""
+        return self._thread is not None and self._thread.is_alive()
+ 
+    def start(self) -> None:
+        """Start the background heartbeat thread.
+ 
+        Calling ``start`` on an already-running keep-alive is a no-op.
+        """
+        if self.is_running:
+            logger.debug("ConnectionKeepAlive already running; start() ignored")
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="ConnectionKeepAlive",
+        )
+        self._thread.start()
+        logger.info(
+            "ConnectionKeepAlive started; pinging every %.1f seconds", self._interval
+        )
+ 
+    def ping(self) -> bool:
+        """Issue a single heartbeat query.
+ 
+        Returns ``True`` if the ping succeeded, ``False`` if it raised. Failures
+        are logged and swallowed so a transient drop never takes down the
+        background loop; the next tick simply tries again.
+        """
+        try:
+            with self._lock:
+                cursor = self._conn.cursor()
+                try:
+                    cursor.execute(self._query)
+                    cursor.fetchone()
+                finally:
+                    close = getattr(cursor, "close", None)
+                    if callable(close):
+                        close()
+            logger.debug("Heartbeat ping succeeded")
+            return True
+        except Exception:
+            logger.warning("Heartbeat ping failed; will retry next interval", exc_info=True)
+            return False
+ 
+    def _run(self) -> None:
+        """Background worker loop.
+ 
+        ``Event.wait`` returns ``True`` when ``stop()`` has been signalled and
+        ``False`` on timeout, so the loop ticks once per interval and exits
+        promptly on shutdown.
+        """
+        while not self._stop_event.wait(self._interval):
+            self.ping()
+ 
+    def stop(self, timeout: Optional[float] = 5.0) -> None:
+        """Signal the background thread to stop and wait for it to exit."""
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+        self._thread = None
+        logger.info("ConnectionKeepAlive stopped")
+ 

--- a/tests/test_connection_keepalive.py
+++ b/tests/test_connection_keepalive.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+ 
+import os
+import sys
+import threading
+import time
+from unittest.mock import MagicMock
+ 
+import pytest
+ 
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+ 
+from database.connection import ConnectionKeepAlive, HEARTBEAT_QUERY
+ 
+ 
+def _make_connection() -> MagicMock:
+    """A fake DB-API connection whose cursor records executed queries."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+ 
+ 
+def test_ping_executes_heartbeat_query():
+    conn = _make_connection()
+    keepalive = ConnectionKeepAlive(conn, interval=30.0)
+ 
+    assert keepalive.ping() is True
+    conn.cursor.assert_called_once()
+    conn.cursor.return_value.execute.assert_called_once_with(HEARTBEAT_QUERY)
+ 
+ 
+def test_ping_returns_false_on_failure_and_does_not_raise():
+    conn = _make_connection()
+    conn.cursor.return_value.execute.side_effect = RuntimeError("connection reset")
+    keepalive = ConnectionKeepAlive(conn, interval=30.0)
+ 
+    # A failed ping must be swallowed so the loop survives a transient drop.
+    assert keepalive.ping() is False
+ 
+ 
+def test_start_launches_background_thread_and_stop_joins_it():
+    conn = _make_connection()
+    keepalive = ConnectionKeepAlive(conn, interval=30.0)
+ 
+    assert keepalive.is_running is False
+    keepalive.start()
+    assert keepalive.is_running is True
+ 
+    keepalive.stop()
+    assert keepalive.is_running is False
+ 
+ 
+def test_background_loop_pings_on_interval():
+    # Use a tiny interval so the loop ticks during the test, and an Event to
+    # detect the first ping deterministically rather than sleeping blindly.
+    conn = _make_connection()
+    pinged = threading.Event()
+    conn.cursor.return_value.execute.side_effect = lambda *_a, **_k: pinged.set()
+ 
+    keepalive = ConnectionKeepAlive(conn, interval=0.05)
+    keepalive.start()
+    try:
+        assert pinged.wait(timeout=2.0), "expected at least one ping within 2s"
+    finally:
+        keepalive.stop()
+ 
+    conn.cursor.return_value.execute.assert_called_with(HEARTBEAT_QUERY)
+ 
+ 
+def test_stop_is_prompt_and_does_not_wait_full_interval():
+    # Large interval; stop() must return quickly via the stop Event, not block
+    # for the whole interval.
+    conn = _make_connection()
+    keepalive = ConnectionKeepAlive(conn, interval=60.0)
+    keepalive.start()
+ 
+    start = time.monotonic()
+    keepalive.stop()
+    elapsed = time.monotonic() - start
+ 
+    assert elapsed < 5.0
+    assert keepalive.is_running is False
+ 
+ 
+def test_double_start_is_noop():
+    conn = _make_connection()
+    keepalive = ConnectionKeepAlive(conn, interval=60.0)
+    keepalive.start()
+    first_thread = keepalive._thread
+    keepalive.start()  # should be ignored, not spawn a second thread
+    assert keepalive._thread is first_thread
+    keepalive.stop()
+ 
+ 
+def test_invalid_arguments_rejected():
+    with pytest.raises(ValueError):
+        ConnectionKeepAlive(None, interval=30.0)
+    with pytest.raises(ValueError):
+        ConnectionKeepAlive(_make_connection(), interval=0)
+    with pytest.raises(ValueError):
+        ConnectionKeepAlive(_make_connection(), interval=-5)
+ 


### PR DESCRIPTION

# feat: #401 background connection keep-alive for relational sink
 
## Summary
 
Adds `src/database/connection.py` with a `ConnectionKeepAlive` class that runs a low-overhead background heartbeat (`SELECT 1;`) on a fixed interval (default 30s) to keep a long-lived relational connection warm during quiet, low-volume market windows.
 
## Motivation
 
Closes #401. Serverless / autoscaled Postgres sinks and intermediary poolers (e.g. PgBouncer) commonly drop idle TCP connections after a short timeout. When the next price record arrives, the first write stalls waiting for a fresh TCP handshake and re-authentication. A periodic heartbeat keeps the channel active so the write path never pays the reconnect cost.
 
## Implementation
 
`ConnectionKeepAlive` mirrors the conventions already in this directory: the threading idiom (daemon thread + lock + `threading.Event`) follows `batch_sink.py`, and the connection style follows the `psycopg2`/PostgreSQL usage in `cleanup_job.py`.
 
- A daemon thread wakes every `interval` seconds and issues `SELECT 1;`.
- `stop()` signals the thread via a `threading.Event`, so shutdown is prompt and does not wait out the full interval.
- A failed ping is logged and swallowed (returns `False`) so a transient drop never kills the background loop — the next tick simply retries.
- `start()` is idempotent; invalid arguments (`None` connection, non-positive interval) are rejected.
## Note on the SQLite vs. Postgres mismatch
 
The keep-alive is written connection-agnostic: it accepts any DB-API 2.0 connection exposing `cursor()`. This is deliberate, because the database layer in this repo is currently inconsistent — `cleanup_job.py` uses `psycopg2`/PostgreSQL (where idle-connection drops are a real phenomenon and this heartbeat is meaningful), while `models.py` and `batch_sink.py` use `sqlite3` (a local file with no socket to keep open, where the ping is harmless but inert). The class and its docstring make this explicit so the behaviour is meaningful for the networked sink the issue describes without misrepresenting what it does against SQLite.
 
## Changes
 
- `src/database/connection.py` *(new)*: `ConnectionKeepAlive` class plus `DEFAULT_PING_INTERVAL` and `HEARTBEAT_QUERY` constants.
- `src/database/__init__.py` *(new)*: package marker so `from database.connection import ...` resolves (the directory previously had none, unlike `src/analytics/`).
- `tests/test_connection_keepalive.py` *(new)*: 7 mock-based unit tests.
## Testing
 
7 new unit tests, all passing:
 
```
python3 -m pytest tests/test_connection_keepalive.py -v
# 7 passed
```
 
They cover: the heartbeat query is executed, failures are swallowed rather than raised, the background thread starts/stops cleanly, the loop pings on its interval, `stop()` returns promptly instead of blocking for the full interval, double-`start()` is a no-op, and invalid arguments are rejected. Tests use `unittest.mock` connections, consistent with the existing Python tests, so no live database is required.
 
Note: the full Python suite has two pre-existing failures unrelated to this change, reproducible on a clean checkout (verified by stashing these files): `tests/test_window.py` fails to import on Python 3.12 (`Deque` was removed from `collections.abc`), and `tests/test_signer.py::TestExceptionPathCleanup::test_signing_error_does_not_abort_cleanup` fails on a read-only-attribute mock. Neither touches the files in this PR.
 