### PR TITLE
Add SecureSessionCredentials context manager with automatic zero-wipe

### DIFF
--- a/src/crypto/signer.py
+++ b/src/crypto/signer.py
@@ -49,7 +49,7 @@ from typing import Optional, Type
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["SecureKeyHandle", "SigningError"]
+__all__ = ["SecureKeyHandle", "SecureSessionCredentials", "SigningError"]
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -312,3 +312,104 @@ class SecureKeyHandle:
             return bytes(sk.sign(tx_hash).signature)
         except Exception as exc:
             raise SigningError("Signing failed (PyNaCl path).") from exc
+
+
+class SecureSessionCredentials:
+    """Context manager that holds temporary session credentials for one validation scope.
+
+    The credentials are copied into an internal ``bytearray`` on construction.
+    On ``__exit__`` — normal *or* exceptional — the buffer is zero-wiped
+    **before** any reference is released, ensuring credentials are not left
+    in process memory after the validation block closes.
+
+    A ``__del__`` finaliser acts as a last-resort safety net: if the caller
+    fails to use the ``with`` statement the buffer is still wiped on garbage
+    collection.
+
+    Args:
+        credentials: Raw session credential bytes (e.g. API token, JWT).
+
+    Raises:
+        ValueError:   If *credentials* is empty.
+        SigningError: If :meth:`get` is called outside the ``with`` block.
+
+    Example::
+
+        with SecureSessionCredentials(token_bytes) as creds:
+            api_token = creds.get()
+            # use api_token for validation ...
+        # Buffer zero-wiped here; creds is no longer usable.
+    """
+
+    __slots__ = ("_buf", "_active", "_wiped")
+
+    def __init__(self, credentials: bytes) -> None:
+        if not credentials:
+            raise ValueError("credentials must be non-empty bytes.")
+        self._buf: bytearray = bytearray(credentials)
+        self._active: bool = False
+        self._wiped: bool = False
+
+    # ------------------------------------------------------------------
+    # Context-manager protocol
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "SecureSessionCredentials":
+        self._active = True
+        logger.debug("[SecureSessionCredentials] Validation scope opened.")
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> bool:
+        self._active = False
+        self._do_wipe()
+        return False
+
+    def __del__(self) -> None:
+        try:
+            self._do_wipe()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _do_wipe(self) -> None:
+        if self._wiped:
+            return
+        self._wiped = True
+        _zero_wipe(self._buf)
+        logger.debug("[SecureSessionCredentials] Validation scope closed — credentials wiped.")
+
+    # ------------------------------------------------------------------
+    # Accessor
+    # ------------------------------------------------------------------
+
+    def get(self) -> bytes:
+        """Return a ``bytes`` copy of the stored session credentials.
+
+        The returned copy is the caller's responsibility to manage.  The
+        internal buffer is unaffected.
+
+        Returns:
+            A ``bytes`` copy of the credentials stored in the handle.
+
+        Raises:
+            SigningError: If called outside the ``with`` block or after the
+                          buffer has already been wiped.
+        """
+        if not self._active:
+            raise SigningError(
+                "SecureSessionCredentials.get() called outside an active validation scope. "
+                "Use 'with SecureSessionCredentials(...) as creds:' and call get() inside."
+            )
+        if self._wiped:
+            raise SigningError(
+                "SecureSessionCredentials.get() called after credentials have been wiped."
+            )
+        return bytes(self._buf)

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -39,7 +39,7 @@ import pytest
 # ---------------------------------------------------------------------------
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from crypto.signer import SecureKeyHandle, SigningError, _zero_wipe  # noqa: E402
+from crypto.signer import SecureKeyHandle, SecureSessionCredentials, SigningError, _zero_wipe  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -482,3 +482,150 @@ class TestRegression:
                 "Key material must not appear in __repr__."
             )
         handle._do_wipe()
+
+
+# ---------------------------------------------------------------------------
+# SecureSessionCredentials
+# ---------------------------------------------------------------------------
+
+
+class TestSecureSessionCredentialsConstruction:
+    def test_rejects_empty_credentials(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            SecureSessionCredentials(b"")
+
+    def test_accepts_valid_credentials(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        assert not creds._active
+        assert not creds._wiped
+        creds._do_wipe()
+
+    def test_buffer_is_independent_copy(self):
+        raw = bytearray(_DUMMY_KEY)
+        creds = SecureSessionCredentials(bytes(raw))
+        raw[0] = 0xFF
+        assert creds._buf[0] == 0x00, "Internal buffer must be an independent copy."
+        creds._do_wipe()
+
+
+class TestSecureSessionCredentialsContextManager:
+    def test_enter_sets_active(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        creds.__enter__()
+        assert creds._active
+        creds.__exit__(None, None, None)
+
+    def test_exit_clears_active(self):
+        with SecureSessionCredentials(_DUMMY_KEY):
+            pass
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        creds.__enter__()
+        creds.__exit__(None, None, None)
+        assert not creds._active
+
+    def test_exit_wipes_buffer_on_success(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        with creds:
+            pass
+        _assert_wiped(creds._buf, "_buf after normal exit")
+
+    def test_exit_sets_wiped_flag(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        with creds:
+            pass
+        assert creds._wiped
+
+    def test_exit_does_not_suppress_exceptions(self):
+        with pytest.raises(RuntimeError, match="propagated"):
+            with SecureSessionCredentials(_DUMMY_KEY):
+                raise RuntimeError("propagated")
+
+    def test_buffer_wiped_even_when_exception_raised(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        try:
+            with creds:
+                raise ValueError("simulated failure")
+        except ValueError:
+            pass
+        _assert_wiped(creds._buf, "_buf after exception exit")
+
+    def test_wipe_is_idempotent_double_exit(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        creds.__enter__()
+        creds.__exit__(None, None, None)
+        creds.__exit__(None, None, None)
+        _assert_wiped(creds._buf, "_buf after double exit")
+
+
+class TestSecureSessionCredentialsDel:
+    def test_del_wipes_buffer_when_context_not_used(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        creds.__del__()
+        _assert_wiped(creds._buf, "_buf after __del__ without context manager")
+        assert creds._wiped
+
+    def test_del_does_not_raise_after_normal_exit(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        with creds:
+            pass
+        creds.__del__()
+
+
+class TestSecureSessionCredentialsGet:
+    def test_get_outside_context_raises(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        with pytest.raises(SigningError, match="outside an active validation scope"):
+            creds.get()
+
+    def test_get_after_exit_raises(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        with creds:
+            pass
+        with pytest.raises(SigningError, match="outside an active validation scope"):
+            creds.get()
+
+    def test_get_after_explicit_wipe_raises(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        creds.__enter__()
+        creds._do_wipe()
+        with pytest.raises(SigningError, match="wiped"):
+            creds.get()
+
+    def test_get_returns_credentials_copy(self):
+        creds = SecureSessionCredentials(_DUMMY_KEY)
+        with creds:
+            result = creds.get()
+        assert isinstance(result, bytes)
+        assert result == _DUMMY_KEY
+
+    def test_get_returns_independent_bytes(self):
+        creds = SecureSessionCredentials(bytes(range(32)))
+        with creds:
+            result = creds.get()
+        assert isinstance(result, bytes)
+        assert len(result) == 32
+
+
+class TestSecureSessionCredentialsLogging:
+    def test_no_credential_bytes_logged(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="crypto.signer"):
+            creds = SecureSessionCredentials(_DUMMY_KEY)
+            with creds:
+                creds.get()
+
+        combined = "\n".join(r.getMessage() for r in caplog.records)
+        for val in set(_DUMMY_KEY):
+            if val == 0:
+                continue
+            assert str(val) not in combined, (
+                f"Credential byte value {val} leaked into log output."
+            )
+
+    def test_log_level_is_debug_only(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="crypto.signer"):
+            with SecureSessionCredentials(_DUMMY_KEY):
+                pass
+        for record in caplog.records:
+            assert record.levelno <= logging.DEBUG, (
+                f"Unexpected log level {record.levelname}: {record.getMessage()}"
+            )


### PR DESCRIPTION
## Description

Leaving temporary session credentials active in system memory after validation completes exposes the platform to access extraction attacks. This PR introduces `SecureSessionCredentials`, a secure context manager class in `src/crypto/signer.py` that encapsulates temporary session credentials and enforces explicit zero-wiping of key material the moment the validation block closes.

## Changes

### `src/crypto/signer.py`

- Added `SecureSessionCredentials` class — a context manager that holds temporary session credentials (API tokens, JWTs, etc.) in a mutable `bytearray` and zero-wipes them on `__exit__`, regardless of whether the block exited normally or via exception.
- The class follows the same security patterns as the existing `SecureKeyHandle`:
  - `ctypes.memset` + Python loop belt-and-suspenders wiping
  - `__del__` finaliser as last-resort safety net
  - `get()` method with guards against out-of-scope / post-wipe access
  - No credential bytes leaked in logs or error messages

### `tests/test_signer.py`

- 19 new tests across 5 test classes covering:
  - Construction (empty rejection, independent buffer copy)
  - Context manager lifecycle (enter/exit, wipe on success/exception, idempotent double-exit)
  - `__del__` finaliser
  - `get()` guards (outside scope, after wipe) and return value correctness
  - Logging security (no credential bytes, DEBUG-only level)




closes #498 