### PR TITLE
feat(utils): atomic temporary file overwrites for persistence engines (#473)

### DIFF
--- a/src/utils/file_sync.py
+++ b/src/utils/file_sync.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def atomic_write_bytes(target: Path | str, data: bytes) -> None:
+    """Persist *data* to *target* using a temporary file and ``os.replace``.
+
+    The update is isolated to a sibling temporary file in the same directory so
+    a crash or power loss during the write cannot leave the live tracking file in
+    a partially-written state.
+    """
+    path = Path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_text(
+    target: Path | str,
+    text: str,
+    *,
+    encoding: str = "utf-8",
+) -> None:
+    """Atomically persist UTF-8 (or custom) text to *target*."""
+    atomic_write_bytes(target, text.encode(encoding))
+
+
+def atomic_write_json(
+    target: Path | str,
+    payload: Any,
+    *,
+    indent: int | None = None,
+    sort_keys: bool = False,
+) -> None:
+    """Atomically persist a JSON document to *target*."""
+    serialized = json.dumps(
+        payload,
+        indent=indent,
+        sort_keys=sort_keys,
+        ensure_ascii=False,
+    )
+    atomic_write_text(target, serialized + "\n")
+
+
+class PersistenceEngine:
+    """Thread-safe local tracking store backed by an on-disk JSON file.
+
+    All writes route through :func:`atomic_write_json` so persistence survives
+    abrupt process termination without corrupting the active tracking file.
+    """
+
+    def __init__(self, tracking_file: Path | str) -> None:
+        self._path = Path(tracking_file)
+        self._lock = threading.Lock()
+        self._state: dict[str, Any] = {}
+        self._load()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            self._state = {}
+            return
+
+        try:
+            raw = self._path.read_text(encoding="utf-8").strip()
+            self._state = json.loads(raw) if raw else {}
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to load tracking file %s: %s", self._path, exc)
+            self._state = {}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        with self._lock:
+            return self._state.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._state[key] = value
+            self._persist_locked()
+
+    def update(self, values: dict[str, Any]) -> None:
+        with self._lock:
+            self._state.update(values)
+            self._persist_locked()
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return dict(self._state)
+
+    def _persist_locked(self) -> None:
+        atomic_write_json(self._path, self._state, sort_keys=True)

--- a/tests/test_file_sync.py
+++ b/tests/test_file_sync.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from utils.file_sync import (
+    PersistenceEngine,
+    atomic_write_bytes,
+    atomic_write_json,
+    atomic_write_text,
+)
+
+
+def test_atomic_write_bytes_creates_target(tmp_path: Path) -> None:
+    target = tmp_path / "tracking.json"
+    atomic_write_bytes(target, b'{"seq": 1}\n')
+
+    assert target.read_bytes() == b'{"seq": 1}\n'
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_text_overwrites_existing(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    target.write_text('{"version": 1}\n', encoding="utf-8")
+
+    atomic_write_text(target, '{"version": 2}\n')
+
+    assert target.read_text(encoding="utf-8") == '{"version": 2}\n'
+
+
+def test_atomic_write_json_serializes_payload(tmp_path: Path) -> None:
+    target = tmp_path / "metrics.json"
+    atomic_write_json(target, {"alpha": 1, "beta": 2}, sort_keys=True)
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"alpha": 1, "beta": 2}
+
+
+def test_atomic_write_cleans_up_temp_file_on_failure(tmp_path: Path) -> None:
+    target = tmp_path / "tracking.json"
+    target.write_text('{"safe": true}\n', encoding="utf-8")
+    original = target.read_text(encoding="utf-8")
+
+    with mock.patch("utils.file_sync.os.replace", side_effect=OSError("rename failed")):
+        with pytest.raises(OSError, match="rename failed"):
+            atomic_write_bytes(target, b'{"safe": false}\n')
+
+    assert target.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_persistence_engine_round_trip(tmp_path: Path) -> None:
+    tracking_file = tmp_path / "worker-state.json"
+    engine = PersistenceEngine(tracking_file)
+
+    engine.set("last_seq", 42)
+    engine.update({"worker": "horizon-poller", "active": True})
+
+    reloaded = PersistenceEngine(tracking_file)
+    assert reloaded.snapshot() == {
+        "last_seq": 42,
+        "worker": "horizon-poller",
+        "active": True,
+    }
+
+
+def test_persistence_engine_uses_atomic_writer(tmp_path: Path) -> None:
+    tracking_file = tmp_path / "worker-state.json"
+    engine = PersistenceEngine(tracking_file)
+
+    with mock.patch("utils.file_sync.atomic_write_json") as writer:
+        engine.set("cursor", 7)
+
+    writer.assert_called_once_with(tracking_file, {"cursor": 7}, sort_keys=True)


### PR DESCRIPTION
## Summary
- Add `src/utils/file_sync.py` with atomic write helpers that persist to a temp file and swap via `os.replace`
- Add `PersistenceEngine` for thread-safe local tracking file persistence
- Add unit tests covering overwrite safety, temp cleanup on failure, and round-trip persistence

Closes #473

## Test plan
- [x] `python -m pytest tests/test_file_sync.py -v` (6 passed)