### PR TITLE
feat: add thread-safe sliding window nonce tracker (#459)

### DIFF
--- a/src/network/nonce_tracker.py
+++ b/src/network/nonce_tracker.py
@@ -149,3 +149,261 @@ class NonceTracker:
 
 # Module-level singleton – import and use directly.
 nonce_tracker = NonceTracker()
+
+
+# ---------------------------------------------------------------------------
+# Sliding-window sequence tracker
+# ---------------------------------------------------------------------------
+
+
+class _AccountWindow:
+    """Per-account mutable state for NonceWindow."""
+
+    __slots__ = ("lock", "base", "next_index", "pending")
+
+    def __init__(self) -> None:
+        self.lock: threading.Lock = threading.Lock()
+        self.base: Optional[int] = None
+        self.next_index: int = 0
+        self.pending: set = set()
+
+
+class NonceWindow:
+    """Thread-safe sliding window of pre-allocated Stellar sequence numbers.
+
+    Unlike a simple sequential counter, ``NonceWindow`` pre-allocates
+    *window_size* consecutive sequence numbers per account upfront.  Each
+    ``acquire()`` call returns a unique slot from the current batch with only
+    a brief critical section (a counter increment), so multiple parallel
+    broadcast workers obtain their sequences almost simultaneously and can
+    then sign and dispatch concurrently without serialising on the tracking
+    layer.
+
+    Sliding behaviour
+    -----------------
+    The window covers the integer range ``[base, base + window_size)``.
+    ``acquire()`` hands out slots in order; ``acknowledge()`` marks a slot as
+    finished.  Whenever the *lowest* in-flight sequence is acknowledged the
+    base advances past every contiguous run of completed leading slots,
+    opening fresh capacity for new ``acquire()`` calls.
+
+    Example with window_size=4 and seed=100
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    acquire() → 100   pending={100}        slots used: 1/4
+    acquire() → 101   pending={100,101}    slots used: 2/4
+    acquire() → 102   pending={100,101,102} slots used: 3/4
+    acknowledge(101)  pending={100,102}    base stays at 100 (100 still live)
+    acknowledge(100)  pending={102}        base slides to 102 (101 already done)
+    acquire() → 103   pending={102,103}    slots used: 2/4  (one slot re-opened)
+
+    Complexity
+    ----------
+    acquire     : O(1) – lock held for a counter increment only.
+    acknowledge : O(W) worst-case (reverse-order completions); O(1) typical.
+    Space       : O(W × A) where W = window_size and A = number of accounts.
+    """
+
+    DEFAULT_WINDOW_SIZE: int = 16
+
+    def __init__(self, window_size: int = DEFAULT_WINDOW_SIZE) -> None:
+        if window_size < 1:
+            raise ValueError("window_size must be a positive integer.")
+        self._window_size = window_size
+        self._accounts: Dict[str, _AccountWindow] = {}
+        self._map_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_account(self, address: str) -> _AccountWindow:
+        acct = self._accounts.get(address)
+        if acct is None:
+            with self._map_lock:
+                acct = self._accounts.get(address)
+                if acct is None:
+                    acct = _AccountWindow()
+                    self._accounts[address] = acct
+        return acct
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def acquire(self, address: str, seed: Optional[int] = None) -> int:
+        """Return the next pre-allocated sequence number for *address*.
+
+        The call is O(1) and holds the per-account lock only for a counter
+        increment, so concurrent workers on the same account contend for
+        nanoseconds rather than the full sign-and-dispatch duration.
+
+        Args:
+            address : Stellar account public key.
+            seed    : On-chain sequence number; required on the first call
+                      for each account (ignored once the window is seeded).
+
+        Returns:
+            A unique sequence integer that will not repeat for *address*
+            while any prior sequences for that account are still pending.
+
+        Raises:
+            ValueError  : Window is unseeded and no *seed* was supplied.
+            RuntimeError: All window slots are in-flight; call
+                          ``acknowledge()`` to release completed sequences
+                          before acquiring more.
+        """
+        acct = self._get_account(address)
+        with acct.lock:
+            if acct.base is None:
+                if seed is None:
+                    raise ValueError(
+                        f"NonceWindow for '{address}' is unseeded; supply a seed."
+                    )
+                acct.base = int(seed)
+                acct.next_index = 0
+                acct.pending.clear()
+                logger.info(
+                    "[NonceWindow] Seeded window for %s → %d (size=%d)",
+                    address,
+                    acct.base,
+                    self._window_size,
+                )
+
+            if acct.next_index >= self._window_size:
+                raise RuntimeError(
+                    f"NonceWindow for '{address}' is exhausted: all "
+                    f"{self._window_size} slots are in-flight. "
+                    "Call acknowledge() to release completed sequences."
+                )
+
+            seq = acct.base + acct.next_index
+            acct.next_index += 1
+            acct.pending.add(seq)
+
+            logger.debug(
+                "[NonceWindow] Issued seq %d for %s (slot %d/%d)",
+                seq,
+                address,
+                acct.next_index,
+                self._window_size,
+            )
+            return seq
+
+    def acknowledge(self, address: str, sequence: int) -> None:
+        """Mark *sequence* as complete and advance the window base if possible.
+
+        After removing the sequence from the pending set the method slides
+        the window base forward past every contiguous run of leading
+        acknowledged slots, opening capacity for fresh ``acquire()`` calls.
+
+        Args:
+            address  : Stellar account public key.
+            sequence : Sequence number returned by a prior ``acquire()`` call.
+        """
+        acct = self._get_account(address)
+        with acct.lock:
+            if sequence not in acct.pending:
+                logger.warning(
+                    "[NonceWindow] acknowledge(%s, %d) – sequence not tracked; "
+                    "ignoring.",
+                    address,
+                    sequence,
+                )
+                return
+
+            acct.pending.discard(sequence)
+
+            # Advance the base past every leading slot that has been both
+            # issued (next_index > 0 guarantees base was issued) and
+            # acknowledged (base is absent from pending).
+            while acct.next_index > 0 and acct.base not in acct.pending:
+                acct.base += 1
+                acct.next_index -= 1
+                logger.debug(
+                    "[NonceWindow] Window slid for %s → base=%d in-flight=%d",
+                    address,
+                    acct.base,
+                    acct.next_index,
+                )
+
+    def sync(self, address: str, sequence: int) -> None:
+        """Realign the window to a known-good on-chain sequence.
+
+        Drops all pending in-flight slots and resets the base to *sequence*.
+        Use this after a ``tx_bad_seq`` error to resynchronise local tracking
+        with the ledger's authoritative value.
+
+        Args:
+            address  : Stellar account public key.
+            sequence : Authoritative sequence number from the ledger.
+        """
+        acct = self._get_account(address)
+        with acct.lock:
+            acct.base = int(sequence)
+            acct.next_index = 0
+            acct.pending.clear()
+            logger.info(
+                "[NonceWindow] Synced window for %s → %d", address, sequence
+            )
+
+    def invalidate(self, address: Optional[str] = None) -> None:
+        """Evict the window for *address*, or all windows when omitted.
+
+        The next ``acquire()`` will require a seed.
+
+        Implementation note: for a full clear a snapshot of existing accounts
+        is taken under ``_map_lock``, which is released before acquiring
+        individual per-account locks to prevent the same deadlock risk
+        described in ``NonceTracker.invalidate``.
+
+        Time: O(1) for a single address; O(A) for a full clear.
+        """
+        if address is not None:
+            acct = self._get_account(address)
+            with acct.lock:
+                acct.base = None
+                acct.next_index = 0
+                acct.pending.clear()
+            logger.info(
+                "[NonceWindow] Invalidated window for %s. Re-seed required.",
+                address,
+            )
+            return
+
+        with self._map_lock:
+            snapshot = list(self._accounts.items())
+
+        for _addr, acct in snapshot:
+            with acct.lock:
+                acct.base = None
+                acct.next_index = 0
+                acct.pending.clear()
+
+        logger.info("[NonceWindow] All windows invalidated. Re-seed required.")
+
+    @property
+    def window_size(self) -> int:
+        """The number of sequences pre-allocated per window batch."""
+        return self._window_size
+
+    def available_slots(self, address: str) -> int:
+        """Return how many sequences can still be acquired in the current window.
+
+        Returns 0 when the window is unseeded or fully exhausted.
+        """
+        acct = self._get_account(address)
+        with acct.lock:
+            if acct.base is None:
+                return 0
+            return self._window_size - acct.next_index
+
+
+# Module-level default window – import and use directly.
+nonce_window = NonceWindow()
+
+__all__ = [
+    "NonceTracker",
+    "NonceWindow",
+    "nonce_tracker",
+    "nonce_window",
+]

--- a/tests/test_nonce_tracker.py
+++ b/tests/test_nonce_tracker.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from network.nonce_tracker import NonceWindow
+
+
+# ---------------------------------------------------------------------------
+# Basic acquire / seed behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_requires_seed_on_first_call() -> None:
+    window = NonceWindow()
+    with pytest.raises(ValueError, match="unseeded"):
+        window.acquire("GACC")
+
+
+def test_acquire_returns_seed_then_increments() -> None:
+    window = NonceWindow()
+    assert window.acquire("GACC", seed=100) == 100
+    assert window.acquire("GACC") == 101
+    assert window.acquire("GACC") == 102
+
+
+def test_seed_ignored_after_window_is_seeded() -> None:
+    window = NonceWindow()
+    window.acquire("GACC", seed=50)
+    # A second seed value supplied here must be ignored.
+    assert window.acquire("GACC", seed=999) == 51
+
+
+# ---------------------------------------------------------------------------
+# Window exhaustion and acknowledge-driven sliding
+# ---------------------------------------------------------------------------
+
+
+def test_exhaustion_raises_when_all_slots_in_flight() -> None:
+    window = NonceWindow(window_size=4)
+    for i in range(4):
+        window.acquire("GACC", seed=0 if i == 0 else None)
+
+    with pytest.raises(RuntimeError, match="exhausted"):
+        window.acquire("GACC")
+
+
+def test_acknowledge_opens_slot_after_exhaustion() -> None:
+    window = NonceWindow(window_size=2)
+    s0 = window.acquire("GACC", seed=10)
+    s1 = window.acquire("GACC")
+
+    with pytest.raises(RuntimeError):
+        window.acquire("GACC")
+
+    window.acknowledge("GACC", s0)
+    # Window should have slid; one new slot is available.
+    s2 = window.acquire("GACC")
+    assert s2 == 12  # base slid to 11 then 11 was issued next
+
+
+def test_window_slides_past_consecutive_leading_acknowledged_slots() -> None:
+    window = NonceWindow(window_size=4)
+    seqs = [window.acquire("GACC", seed=100 if i == 0 else None) for i in range(4)]
+
+    # Acknowledge out of order: 101 first, then 100.
+    window.acknowledge("GACC", seqs[1])  # 101 done; base stays at 100
+    assert window.available_slots("GACC") == 0  # window still full
+
+    window.acknowledge("GACC", seqs[0])  # 100 done; base slides past 100 and 101
+    assert window.available_slots("GACC") == 2  # two slots freed (100 and 101)
+
+    # The next sequences issued must continue from 104.
+    assert window.acquire("GACC") == 104
+    assert window.acquire("GACC") == 105
+
+
+def test_full_window_drains_and_resets_base() -> None:
+    window = NonceWindow(window_size=3)
+    seqs = [window.acquire("GACC", seed=7 if i == 0 else None) for i in range(3)]
+
+    for s in seqs:
+        window.acknowledge("GACC", s)
+
+    # All three acknowledged; base should now be at 10 with zero in-flight.
+    assert window.available_slots("GACC") == 3
+    assert window.acquire("GACC") == 10
+
+
+# ---------------------------------------------------------------------------
+# Available slots reporting
+# ---------------------------------------------------------------------------
+
+
+def test_available_slots_tracks_issued_count() -> None:
+    window = NonceWindow(window_size=8)
+    assert window.available_slots("GACC") == 0  # unseeded
+
+    window.acquire("GACC", seed=1)
+    assert window.available_slots("GACC") == 7
+
+    window.acquire("GACC")
+    assert window.available_slots("GACC") == 6
+
+
+# ---------------------------------------------------------------------------
+# Sync resets the window to a ledger-authoritative value
+# ---------------------------------------------------------------------------
+
+
+def test_sync_discards_pending_and_resets_base() -> None:
+    window = NonceWindow(window_size=4)
+    window.acquire("GACC", seed=50)
+    window.acquire("GACC")
+
+    window.sync("GACC", 200)
+
+    assert window.available_slots("GACC") == 4
+    assert window.acquire("GACC") == 200
+
+
+# ---------------------------------------------------------------------------
+# Invalidate clears one or all windows
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_single_account_requires_reseed() -> None:
+    window = NonceWindow()
+    window.acquire("GA", seed=10)
+    window.acquire("GB", seed=20)
+
+    window.invalidate("GA")
+
+    with pytest.raises(ValueError, match="unseeded"):
+        window.acquire("GA")
+
+    # GB must be unaffected.
+    assert window.acquire("GB") == 21
+
+
+def test_invalidate_all_clears_every_account() -> None:
+    window = NonceWindow()
+    window.acquire("GA", seed=1)
+    window.acquire("GB", seed=2)
+
+    window.invalidate()
+
+    for addr in ("GA", "GB"):
+        with pytest.raises(ValueError, match="unseeded"):
+            window.acquire(addr)
+
+
+# ---------------------------------------------------------------------------
+# Account isolation
+# ---------------------------------------------------------------------------
+
+
+def test_independent_accounts_do_not_share_window_state() -> None:
+    window = NonceWindow(window_size=4)
+    window.acquire("GA", seed=100)  # GA → 100
+    window.acquire("GB", seed=200)  # GB → 200
+    window.acquire("GA")            # GA → 101
+
+    assert window.acquire("GA") == 102  # GA: third call
+    assert window.acquire("GB") == 201  # GB: second call
+
+
+# ---------------------------------------------------------------------------
+# Acknowledge edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_acknowledge_unknown_sequence_is_a_no_op() -> None:
+    window = NonceWindow()
+    window.acquire("GACC", seed=5)
+    # Should not raise; just logs a warning.
+    window.acknowledge("GACC", 9999)
+    assert window.available_slots("GACC") == NonceWindow.DEFAULT_WINDOW_SIZE - 1
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety: concurrent acquire across workers
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_acquire_produces_unique_sequences() -> None:
+    """All sequences issued under parallel pressure must be unique."""
+    window = NonceWindow(window_size=64)
+    window.acquire("GACC", seed=0)  # seed
+
+    results: list[int] = []
+    lock = threading.Lock()
+
+    def worker(_: int) -> None:
+        seq = window.acquire("GACC")
+        with lock:
+            results.append(seq)
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        list(executor.map(worker, range(63)))  # 63 + 1 seed = 64 total
+
+    assert len(results) == 63
+    all_seqs = [0] + results
+    assert len(set(all_seqs)) == 64, "Duplicate sequences detected"
+    assert sorted(all_seqs) == list(range(64))
+
+
+def test_concurrent_acquire_across_different_accounts_no_contention() -> None:
+    """Workers on distinct accounts must never interfere."""
+    window = NonceWindow(window_size=32)
+    accounts = [f"G{i:04d}" for i in range(8)]
+
+    # Seed each account deterministically before releasing workers.
+    for i, acct in enumerate(accounts):
+        window.acquire(acct, seed=1000 * (i + 1))
+
+    collected: dict[str, list[int]] = {a: [] for a in accounts}
+    collected_lock = threading.Lock()
+
+    def worker(account: str) -> None:
+        seq = window.acquire(account)
+        with collected_lock:
+            collected[account].append(seq)
+
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        futures = [executor.submit(worker, a) for a in accounts for _ in range(7)]
+        for f in as_completed(futures):
+            f.result()
+
+    for acct, seqs in collected.items():
+        assert len(set(seqs)) == len(seqs), f"Duplicates for {acct}"
+        # Each account's sequences must form a contiguous range.
+        assert set(seqs) == set(range(min(seqs), min(seqs) + len(seqs)))
+
+
+def test_acknowledge_and_acquire_concurrent_no_data_race() -> None:
+    """Mixed acquire/acknowledge calls under thread pressure must not corrupt state."""
+    window = NonceWindow(window_size=8)
+    issued: list[int] = []
+    issued_lock = threading.Lock()
+    errors: list[Exception] = []
+
+    # Seed the window.
+    window.acquire("GACC", seed=0)
+
+    def acquirer(_: int) -> None:
+        try:
+            seq = window.acquire("GACC")
+            with issued_lock:
+                issued.append(seq)
+        except RuntimeError:
+            pass  # window full; acceptable under high concurrency
+
+    def acknowledger(_: int) -> None:
+        try:
+            with issued_lock:
+                if issued:
+                    seq = issued[0]
+            window.acknowledge("GACC", seq)
+        except Exception as exc:
+            errors.append(exc)
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        futures = [
+            executor.submit(acquirer if i % 2 == 0 else acknowledger, i)
+            for i in range(32)
+        ]
+        for f in as_completed(futures):
+            f.result()
+
+    assert not errors, f"Unexpected errors during concurrent test: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# window_size property
+# ---------------------------------------------------------------------------
+
+
+def test_window_size_property_reflects_constructor_argument() -> None:
+    assert NonceWindow(window_size=8).window_size == 8
+    assert NonceWindow().window_size == NonceWindow.DEFAULT_WINDOW_SIZE
+
+
+def test_invalid_window_size_raises() -> None:
+    with pytest.raises(ValueError):
+        NonceWindow(window_size=0)
+    with pytest.raises(ValueError):
+        NonceWindow(window_size=-1)


### PR DESCRIPTION
## Summary

- Introduces `NonceWindow` in `src/network/nonce_tracker.py` — a pre-allocating, sliding-window sequence tracker that eliminates per-sequence lock contention for parallel broadcast workers
- Workers call `acquire()` to receive a unique slot from a pre-allocated batch of `window_size` sequences (O(1), lock held for a counter increment only); `acknowledge()` marks a slot complete and slides the window base past any contiguous leading run of finished sequences, opening fresh capacity without round-tripping to the ledger
- `sync()` and `invalidate()` handle bad-seq recovery and cache eviction; a module-level `nonce_window` singleton is exported for drop-in use alongside the existing `nonce_tracker`

## Changes

- `src/network/nonce_tracker.py` — added `_AccountWindow` (per-account mutable state) and `NonceWindow` (sliding window tracker) with full docstrings and a `__all__` export list
- `tests/test_nonce_tracker.py` — 18 new tests covering seeding, window exhaustion, out-of-order acknowledgment, sliding behaviour, sync/invalidate, account isolation, and concurrent acquire/acknowledge under thread pressure

## Test plan

- [ ] `python -m pytest tests/test_nonce_tracker.py -v` — all 18 tests pass
- [ ] Verify `acquire()` raises `ValueError` when called unseeded without a seed
- [ ] Verify `acquire()` raises `RuntimeError` when all `window_size` slots are in-flight
- [ ] Verify `acknowledge()` slides the window base forward past consecutive completed leading slots
- [ ] Verify concurrent workers on the same account receive unique, non-repeating sequences
- [ ] Verify workers on different accounts never share or corrupt each other's window state

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
