### PR TITLE
feat(stellarflow-backend): database-pipeline-batching-relational-insert-ope

### DIFF
--- a/src/database/writer.py
+++ b/src/database/writer.py
@@ -1,30 +1,28 @@
 #!/usr/bin/env python3
 """
-Automatic Weekly Table Partitioning Router for Telemetry Logs
-==============================================================
+Database writers for telemetry persistence.
+============================================
 
-Splits incoming telemetry records across weekly tables (e.g.
-``telemetry_2024_W01``, ``telemetry_2024_W02``, …) based on a raw Unix-
-timestamp field in the payload. Partitions are created on-demand so that
-historical ingestion never collides with the active insert path.
+* **RelationalWriter** (Issue #579) – PostgreSQL bulk insert with buffered
+  batching via ``psycopg2.extras.execute_values``.  Rows are flushed when
+  the buffer reaches 50 records or every 1000 ms, whichever comes first.
 
-Design goals
-------------
-* **Non-invasive** – acts as a thin proxy in front of any existing
-  ``src.database.batch_sink.BatchSink`` instance.
-* **Zero-copy insert path** – records are buffered and flushed by the
-  underlying ``BatchSink`` exactly as before; the router only rewrites
-  the per-write target table name.
-* **Auto-schema** – when a new calendar week is encountered the router
-  creates the child table in a short ``CREATE TABLE IF NOT EXISTS`` call.
-  The DDL is executed synchronously on the writer thread but is fast
-  enough to not impact throughput (a few milliseconds at most).
-* **SQLite-first** – same primitive surface as the surrounding modules
-  (``sqlite3``), but written with standard SQL so it can be ported to
-  Postgres with minor tweaks (``GENERATED ALWAYS AS`` partitions instead
-  of manual routing).
+* **PartitionedTelemetryWriter** – weekly SQLite partition router in front
+  of ``BatchSink``.  Splits incoming telemetry records across weekly tables
+  (e.g. ``telemetry_2024_W01``, ``telemetry_2024_W02``, …) based on a raw
+  Unix-timestamp field in the payload.
 
-Usage::
+RelationalWriter usage::
+
+    import psycopg2
+    from src.database.writer import RelationalWriter
+
+    conn = psycopg2.connect(database_url)
+    writer = RelationalWriter(conn, table_name="telemetry")
+    writer.save({"asset_id": "NGN/XLM", "price": 12345, "ts": 1700000000})
+    writer.shutdown()
+
+PartitionedTelemetryWriter usage::
 
     import sqlite3
     from src.database.batch_sink import BatchSink
@@ -34,13 +32,13 @@ Usage::
     base_sink = BatchSink(conn, table_name='telemetry', flush_interval=2.0)
     writer = PartitionedTelemetryWriter(
         base_sink,
-        timestamp_field='ts',   # Unix-epoch seconds or milliseconds field in the payload
+        timestamp_field='ts',
     )
 
     writer.save({
         "asset_id": "xlm-usdc",
         "price": 0.12,
-        "ts": 1700000000,   # → routed to telemetry_2023_W48 or similar
+        "ts": 1700000000,
     })
 """
 
@@ -50,10 +48,156 @@ import logging
 import sqlite3
 import threading
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set
+
 from .batch_sink import BatchSink
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 50
+DEFAULT_FLUSH_INTERVAL_MS = 1000.0
+
+
+def _execute_values_bulk(cursor: Any, sql: str, values: List[tuple], page_size: int) -> None:
+    """Bulk-insert helper; separated for test patching."""
+    try:
+        from psycopg2.extras import execute_values
+    except ImportError as exc:
+        raise RuntimeError(
+            "psycopg2 is required for RelationalWriter bulk inserts"
+        ) from exc
+    execute_values(cursor, sql, values, page_size=page_size)
+
+
+# ---------------------------------------------------------------------------
+# RelationalWriter – PostgreSQL bulk insert (Issue #579)
+# ---------------------------------------------------------------------------
+
+class RelationalWriter:
+    """Thread-safe transactional buffer for batched PostgreSQL inserts.
+
+    Rows are flushed when either:
+
+    * the buffer reaches ``batch_size`` records (default 50), or
+    * the background timer fires every ``flush_interval_ms`` (default 1000 ms).
+    """
+
+    def __init__(
+        self,
+        connection: Any,
+        table_name: str = "telemetry",
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        flush_interval_ms: float = DEFAULT_FLUSH_INTERVAL_MS,
+    ) -> None:
+        if connection is None:
+            raise ValueError("connection must not be None")
+        if batch_size < 1:
+            raise ValueError("batch_size must be at least 1")
+        if flush_interval_ms <= 0:
+            raise ValueError("flush_interval_ms must be positive")
+
+        self._conn = connection
+        self._table = table_name
+        self._batch_size = batch_size
+        self._interval = flush_interval_ms / 1000.0
+        self._buffer: List[Dict[str, Any]] = []
+        self._lock = threading.Lock()
+        self._flush_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="RelationalWriter-Flusher",
+        )
+        self._thread.start()
+        logger.debug(
+            "RelationalWriter initialized for table %s "
+            "(batch_size=%d, flush_interval_ms=%.0f)",
+            self._table,
+            self._batch_size,
+            flush_interval_ms,
+        )
+
+    def save(self, data: Dict[str, Any]) -> None:
+        """Add a compiled row to the in-memory buffer.
+
+        Triggers an immediate flush when the buffer reaches ``batch_size``.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("data must be a dict mapping column names to values")
+
+        should_flush = False
+        with self._lock:
+            self._buffer.append(data)
+            if len(self._buffer) >= self._batch_size:
+                should_flush = True
+
+        if should_flush:
+            self._flush()
+
+    def _run(self) -> None:
+        """Background worker that flushes buffered rows on a fixed interval."""
+        while not self._stop_event.wait(self._interval):
+            try:
+                self._flush()
+            except Exception as exc:  # pragma: no cover – defensive
+                logger.exception(
+                    "Unexpected error while flushing RelationalWriter: %s", exc
+                )
+
+    def _flush(self) -> None:
+        """Bulk-insert buffered rows inside a single database transaction."""
+        with self._flush_lock:
+            with self._lock:
+                if not self._buffer:
+                    return
+                batch = self._buffer.copy()
+                self._buffer.clear()
+
+            logger.debug(
+                "Flushing %d records to table %s via execute_values",
+                len(batch),
+                self._table,
+            )
+
+            columns = list(batch[0].keys())
+            column_clause = ", ".join(columns)
+            sql = f"INSERT INTO {self._table} ({column_clause}) VALUES %s"
+            values = [tuple(row[col] for col in columns) for row in batch]
+
+            cursor = self._conn.cursor()
+            try:
+                _execute_values_bulk(cursor, sql, values, page_size=len(values))
+                self._conn.commit()
+                logger.debug("Successfully flushed %d records", len(batch))
+            except Exception:
+                self._conn.rollback()
+                with self._lock:
+                    self._buffer = batch + self._buffer
+                logger.exception(
+                    "Failed to flush RelationalWriter; records re-queued"
+                )
+                raise
+            finally:
+                close = getattr(cursor, "close", None)
+                if callable(close):
+                    close()
+
+    def shutdown(self) -> None:
+        """Stop the background flusher and persist any remaining rows."""
+        self._stop_event.set()
+        self._thread.join()
+        try:
+            self._flush()
+        except Exception as exc:  # pragma: no cover – defensive
+            logger.exception(
+                "Error during final RelationalWriter shutdown flush: %s", exc
+            )
+        logger.info(
+            "RelationalWriter shutdown complete; %d records remaining in buffer",
+            len(self._buffer),
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from database.writer import DEFAULT_BATCH_SIZE, RelationalWriter
+
+
+def _make_connection() -> MagicMock:
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+def test_save_rejects_non_dict():
+    writer = RelationalWriter(_make_connection())
+    try:
+        with pytest.raises(TypeError):
+            writer.save(["not", "a", "dict"])  # type: ignore[arg-type]
+    finally:
+        writer.shutdown()
+
+
+def test_save_rejects_invalid_arguments():
+    with pytest.raises(ValueError):
+        RelationalWriter(None)
+    with pytest.raises(ValueError):
+        RelationalWriter(_make_connection(), batch_size=0)
+    with pytest.raises(ValueError):
+        RelationalWriter(_make_connection(), flush_interval_ms=0)
+
+
+def test_flush_on_batch_size_uses_execute_values():
+    conn = _make_connection()
+    writer = RelationalWriter(conn, batch_size=3, flush_interval_ms=60_000)
+
+    try:
+        with patch("database.writer._execute_values_bulk") as execute_values:
+            for index in range(3):
+                writer.save({"asset_id": f"asset-{index}", "price": index})
+
+            execute_values.assert_called_once()
+            sql = execute_values.call_args.args[1]
+            values = execute_values.call_args.args[2]
+            assert "INSERT INTO telemetry (asset_id, price) VALUES %s" == sql
+            assert len(values) == 3
+            conn.commit.assert_called_once()
+    finally:
+        writer.shutdown()
+
+
+def test_interval_flush_runs_in_background():
+    conn = _make_connection()
+    flushed = threading.Event()
+
+    def _execute_values(_cursor, _sql, _values, page_size):
+        flushed.set()
+
+    writer = RelationalWriter(conn, batch_size=50, flush_interval_ms=50)
+
+    try:
+        with patch("database.writer._execute_values_bulk", side_effect=_execute_values):
+            writer.save({"asset_id": "NGN/XLM", "price": 1})
+            assert flushed.wait(timeout=2.0), "expected timed flush within 2s"
+    finally:
+        writer.shutdown()
+
+
+def test_failed_flush_requeues_records():
+    conn = _make_connection()
+    writer = RelationalWriter(conn, batch_size=2, flush_interval_ms=60_000)
+
+    try:
+        with patch(
+            "database.writer._execute_values_bulk",
+            side_effect=RuntimeError("connection reset"),
+        ):
+            writer.save({"asset_id": "a", "price": 1})
+            with pytest.raises(RuntimeError, match="connection reset"):
+                writer.save({"asset_id": "b", "price": 2})
+
+        conn.rollback.assert_called_once()
+
+        with patch("database.writer._execute_values_bulk") as execute_values:
+            writer._flush()
+            assert execute_values.call_args.args[2] == [("a", 1), ("b", 2)]
+    finally:
+        writer.shutdown()
+
+
+def test_shutdown_flushes_remaining_rows():
+    conn = _make_connection()
+    writer = RelationalWriter(conn, batch_size=DEFAULT_BATCH_SIZE, flush_interval_ms=60_000)
+
+    with patch("database.writer._execute_values_bulk") as execute_values:
+        writer.save({"asset_id": "solo", "price": 99})
+        writer.shutdown()
+        execute_values.assert_called_once()
+        assert execute_values.call_args.args[2] == [("solo", 99)]


### PR DESCRIPTION
Closes #579

## Summary
- 🗄️ Database-Pipeline | Batching Relational Insert Operations via Bulk Array Buffers

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths