### PR TITLE
fix(config): enforce immutability on runtime config (#580)

### DIFF
--- a/src/config/configWatcher.ts
+++ b/src/config/configWatcher.ts
@@ -58,33 +58,66 @@ const DEFAULTS: AppConfig = {
   },
 };
 
-function loadConfig(): AppConfig {
+function deepFreeze<T extends object>(obj: T): Readonly<T> {
+  for (const value of Object.values(obj)) {
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      !Object.isFrozen(value)
+    ) {
+      deepFreeze(value as object);
+    }
+  }
+  return Object.freeze(obj);
+}
+
+function buildConfig(parsed: Partial<AppConfig>): Readonly<AppConfig> {
+  return deepFreeze({
+    ...DEFAULTS,
+    ...parsed,
+    rateLimit: { ...DEFAULTS.rateLimit, ...(parsed.rateLimit ?? {}) },
+    sandbox: { ...DEFAULTS.sandbox, ...(parsed.sandbox ?? {}) },
+  });
+}
+
+function loadConfig(): Readonly<AppConfig> {
   try {
     const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
-    const parsed: Partial<AppConfig> = JSON.parse(raw);
-    return {
-      ...DEFAULTS,
-      ...parsed,
-      rateLimit: { ...DEFAULTS.rateLimit, ...(parsed.rateLimit ?? {}) },
-      sandbox: { ...DEFAULTS.sandbox, ...(parsed.sandbox ?? {}) },
-    };
+    return buildConfig(JSON.parse(raw) as Partial<AppConfig>);
   } catch {
-    return { ...DEFAULTS, rateLimit: { ...DEFAULTS.rateLimit }, sandbox: { ...DEFAULTS.sandbox } };
+    return buildConfig({});
   }
 }
 
-// Singleton in-memory config — mutated on reload
-export const appConfig: AppConfig = loadConfig();
+// Internal mutable reference — replaced atomically on reload; never mutated in place
+let _appConfig: Readonly<AppConfig> = loadConfig();
+
+/** Returns the current frozen application configuration snapshot. */
+export function getAppConfig(): Readonly<AppConfig> {
+  return _appConfig;
+}
+
+/**
+ * @deprecated Use {@link getAppConfig} instead.
+ * Kept for backward compatibility — reads from the same internal reference.
+ */
+export const appConfig: Readonly<AppConfig> = new Proxy(
+  {} as Readonly<AppConfig>,
+  {
+    get(_target, prop) {
+      return (_appConfig as Record<string | symbol, unknown>)[prop];
+    },
+  },
+);
 
 /**
  * Starts a fs.watch watcher on config.json.
- * On change, merges the new values into the shared `appConfig` object so all
- * consumers that hold a reference to it see the update immediately.
+ * On change, builds a new frozen config and replaces the internal reference atomically.
  * Calls the optional `onChange` callback with the updated config after each reload.
  * Returns a cleanup function that stops the watcher.
  */
 export function watchConfig(
-  onChange?: (config: AppConfig) => void,
+  onChange?: (config: Readonly<AppConfig>) => void,
 ): () => void {
   if (!fs.existsSync(CONFIG_PATH)) {
     console.warn(
@@ -97,30 +130,17 @@ export function watchConfig(
     if (event !== "change") return;
     try {
       const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
-      const updated: Partial<AppConfig> = JSON.parse(raw);
-      Object.assign(appConfig, DEFAULTS, updated);
-      if (updated.rateLimit) {
-        Object.assign(
-          appConfig.rateLimit,
-          DEFAULTS.rateLimit,
-          updated.rateLimit,
-        );
-      }
+      const updated = buildConfig(JSON.parse(raw) as Partial<AppConfig>);
+      _appConfig = updated;
       if (updated.sandbox) {
-        Object.assign(
-          appConfig.sandbox,
-          DEFAULTS.sandbox,
-          updated.sandbox,
-        );
-        // Sync sandbox policy with new config
         try {
-          dbSandbox.syncWithConfig(appConfig);
+          dbSandbox.syncWithConfig(updated);
         } catch (err) {
           console.error("[ConfigWatcher] Failed to sync sandbox policy:", err);
         }
       }
-      console.info("[ConfigWatcher] config.json reloaded:", appConfig);
-      onChange?.(appConfig);
+      console.info("[ConfigWatcher] config.json reloaded:", updated);
+      onChange?.(updated);
     } catch (err) {
       console.error("[ConfigWatcher] Failed to reload config.json:", err);
     }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -9,16 +9,18 @@ import {
   renderPDF,
 } from "../services/reportService";
 import { updateSecretKey } from "../services/secretManager";
-import { appConfig, CONFIG_PATH } from "../config/configWatcher";
+import { getAppConfig, CONFIG_PATH } from "../config/configWatcher";
 import { refreshWhitelistCache } from "../middleware/rateLimitMiddleware";
-import { getRelayerRegistry, getRelayerRegistryById } from "../controllers/adminController";
+import {
+  getRelayerRegistry,
+  getRelayerRegistryById,
+} from "../controllers/adminController";
 
 const rateLimitUpdateSchema = Joi.object({
   windowMs: Joi.number().integer().min(1000).max(86400000).optional(),
   maxRequests: Joi.number().integer().min(1).max(100000).optional(),
   enabled: Joi.boolean().optional(),
 });
-
 
 const router = Router();
 
@@ -70,7 +72,12 @@ router.get("/reports/summary", async (req, res) => {
   const month = req.query.month as string | undefined;
 
   if (month && !/^\d{4}-\d{2}$/.test(month)) {
-    sendApiError(res, 400, "BAD_REQUEST", "Invalid month format. Use YYYY-MM (e.g. 2025-03).");
+    sendApiError(
+      res,
+      400,
+      "BAD_REQUEST",
+      "Invalid month format. Use YYYY-MM (e.g. 2025-03).",
+    );
     return;
   }
 
@@ -101,7 +108,20 @@ router.get("/reports/summary", async (req, res) => {
     res.send(renderHTML(summary));
   } catch (error) {
     console.error("[AdminReports] Failed to generate report:", error);
-    sendApiError(res, 500, "INTERNAL_SERVER_ERROR", typeof (error instanceof Error ? error.message : "Failed to generate report") === "string" ? String(error instanceof Error ? error.message : "Failed to generate report") : undefined);
+    sendApiError(
+      res,
+      500,
+      "INTERNAL_SERVER_ERROR",
+      typeof (error instanceof Error
+        ? error.message
+        : "Failed to generate report") === "string"
+        ? String(
+            error instanceof Error
+              ? error.message
+              : "Failed to generate report",
+          )
+        : undefined,
+    );
   }
 });
 
@@ -143,7 +163,12 @@ router.post("/reload-secret", async (req, res) => {
       const envKey =
         process.env.ORACLE_SECRET_KEY || process.env.SOROBAN_ADMIN_SECRET;
       if (!envKey) {
-        return sendApiError(res, 500, "INTERNAL_SERVER_ERROR", "Failed to reload secret key");
+        return sendApiError(
+          res,
+          500,
+          "INTERNAL_SERVER_ERROR",
+          "Failed to reload secret key",
+        );
       }
       updateSecretKey(envKey, "admin-endpoint");
     }
@@ -159,10 +184,20 @@ router.post("/reload-secret", async (req, res) => {
       message === "Invalid Stellar secret key format";
 
     if (isValidationError) {
-      return sendApiError(res, 400, "BAD_REQUEST", typeof (message) === "string" ? String(message) : undefined);
+      return sendApiError(
+        res,
+        400,
+        "BAD_REQUEST",
+        typeof message === "string" ? String(message) : undefined,
+      );
     }
 
-    return sendApiError(res, 500, "INTERNAL_SERVER_ERROR", "Failed to reload secret key");
+    return sendApiError(
+      res,
+      500,
+      "INTERNAL_SERVER_ERROR",
+      "Failed to reload secret key",
+    );
   }
 });
 
@@ -258,10 +293,7 @@ router.put("/rate-limit", async (req, res) => {
     });
   }
 
-  // Apply to in-memory config immediately (takes effect on next request)
-  Object.assign(appConfig.rateLimit, value);
-
-  // Persist to config.json so the change survives a restart
+  // Persist to config.json — watchConfig will reload and replace the frozen snapshot atomically
   try {
     let fileConfig: Record<string, unknown> = {};
     try {
@@ -282,18 +314,23 @@ router.put("/rate-limit", async (req, res) => {
     );
   } catch (err) {
     console.error("[AdminRateLimit] Failed to persist config.json:", err);
-    return sendApiError(res, 500, "INTERNAL_SERVER_ERROR", "Rate-limit updated in memory but failed to persist to disk");
+    return sendApiError(
+      res,
+      500,
+      "INTERNAL_SERVER_ERROR",
+      "Rate-limit updated in memory but failed to persist to disk",
+    );
   }
 
   console.info(
     "[AdminRateLimit] Rate-limit config updated:",
-    appConfig.rateLimit,
+    getAppConfig().rateLimit,
   );
 
   return res.json({
     success: true,
     message: "Rate-limit configuration updated",
-    rateLimit: appConfig.rateLimit,
+    rateLimit: getAppConfig().rateLimit,
   });
 });
 
@@ -320,7 +357,12 @@ router.post("/rate-limit/whitelist/refresh", async (_req, res) => {
     });
   } catch (err) {
     console.error("[AdminRateLimit] Whitelist refresh failed:", err);
-    return sendApiError(res, 500, "INTERNAL_SERVER_ERROR", "Failed to refresh whitelist cache");
+    return sendApiError(
+      res,
+      500,
+      "INTERNAL_SERVER_ERROR",
+      "Failed to refresh whitelist cache",
+    );
   }
 });
 


### PR DESCRIPTION
closes #580 
- Deep-freeze AppConfig after load; all nested objects are frozen
- Replace mutable singleton with atomic reference swap on hot-reload
- Add getAppConfig() accessor; keep appConfig Proxy for compatibility
- Remove Object.assign(appConfig.rateLimit) mutation in admin route