### PR TITLE
Add fast SHA-256 digest map bindings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,7 @@ aiohttp>=3.9.0
 
 # Async PostgreSQL driver for high-performance bulk inserts
 asyncpg>=0.28.0
+
+# Test/benchmark verification
+pytest>=8.0.0
+pytest-benchmark>=4.0.0

--- a/src/utils/crypto_hash.py
+++ b/src/utils/crypto_hash.py
@@ -1,0 +1,83 @@
+"""Fast SHA-256 helpers for validator payload state maps.
+
+The module resolves the fastest available CPython-backed SHA-256 constructor at
+import time and keeps that callable in a module-local binding for hot paths.
+"""
+from __future__ import annotations
+
+import hashlib
+import platform
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+Payload = bytes | bytearray | memoryview
+
+
+@dataclass(frozen=True)
+class HashBackend:
+    name: str
+    c_accelerated: bool
+    detail: str
+
+
+def _resolve_sha256():
+    runtime = platform.python_implementation()
+
+    if runtime == "CPython":
+        try:
+            from _hashlib import openssl_sha256
+
+            openssl_sha256(b"").digest()
+            return openssl_sha256, HashBackend(
+                name="openssl_sha256",
+                c_accelerated=True,
+                detail="_hashlib OpenSSL SHA-256 binding",
+            )
+        except Exception:
+            pass
+
+    try:
+        sha256 = hashlib.sha256
+        sha256(b"").digest()
+        module = getattr(sha256, "__module__", "")
+        accelerated = runtime == "CPython" and module in {"_hashlib", "_sha2"}
+        return sha256, HashBackend(
+            name="hashlib.sha256",
+            c_accelerated=accelerated,
+            detail=f"{module or 'hashlib'} SHA-256 constructor",
+        )
+    except Exception as exc:
+        raise RuntimeError("No usable SHA-256 backend is available") from exc
+
+
+_SHA256, BACKEND = _resolve_sha256()
+BACKEND_NAME = BACKEND.name
+C_BINDINGS_LOADED = BACKEND.c_accelerated
+
+
+def sha256_digest(payload: Payload) -> bytes:
+    """Return a 32-byte SHA-256 digest for a validator payload."""
+    return _SHA256(payload).digest()
+
+
+def sha256_hexdigest(payload: Payload) -> str:
+    """Return a hex SHA-256 digest for storage and diagnostics."""
+    return _SHA256(payload).hexdigest()
+
+
+def digest_payload_map(payloads: Iterable[Payload]) -> dict[bytes, Payload]:
+    """Map binary SHA-256 digests to payloads with minimal hot-path overhead."""
+    sha256 = _SHA256
+    return {sha256(payload).digest(): payload for payload in payloads}
+
+
+def hexdigest_payload_map(payloads: Iterable[Payload]) -> dict[str, Payload]:
+    """Map hex SHA-256 digests to payloads for JSON-friendly state maps."""
+    sha256 = _SHA256
+    return {sha256(payload).hexdigest(): payload for payload in payloads}
+
+
+def verify_digest_map(digest_map: Mapping[bytes, Payload]) -> bool:
+    """Validate that every key matches the SHA-256 digest of its payload."""
+    sha256 = _SHA256
+    return all(digest == sha256(payload).digest() for digest, payload in digest_map.items())

--- a/tests/test_crypto_hash.py
+++ b/tests/test_crypto_hash.py
@@ -1,0 +1,62 @@
+import hashlib
+import platform
+
+import pytest
+
+from utils import crypto_hash
+
+
+PAYLOAD = (
+    b'{"validator":"stellar-africa-01","sequence":18446744073709551615,'
+    b'"signature":"b3d1a247c4f72a94e4f9279c0af6c7f8"}'
+)
+
+
+def _mean_seconds(benchmark) -> float:
+    stats = getattr(benchmark, "stats", None)
+    stats = getattr(stats, "stats", stats)
+    mean = getattr(stats, "mean", None)
+    if mean is None:
+        mean = stats["mean"]
+    return float(mean)
+
+
+def test_c_bindings_loaded_on_cpython():
+    if platform.python_implementation() != "CPython":
+        pytest.skip("C-extension binding requirement applies to CPython")
+
+    assert crypto_hash.C_BINDINGS_LOADED is True
+    assert crypto_hash.BACKEND.name in {"openssl_sha256", "hashlib.sha256"}
+
+
+def test_sha256_digest_matches_hashlib():
+    assert crypto_hash.sha256_digest(PAYLOAD) == hashlib.sha256(PAYLOAD).digest()
+    assert crypto_hash.sha256_hexdigest(PAYLOAD) == hashlib.sha256(PAYLOAD).hexdigest()
+
+
+def test_digest_payload_map_and_verify():
+    payloads = [PAYLOAD, PAYLOAD + b"-2", memoryview(PAYLOAD + b"-3")]
+
+    digest_map = crypto_hash.digest_payload_map(payloads)
+
+    assert len(digest_map) == len(payloads)
+    assert crypto_hash.verify_digest_map(digest_map)
+
+
+@pytest.mark.benchmark(group="crypto_hash")
+def test_payload_hashing_under_15_microseconds_per_packet(benchmark):
+    result = benchmark(crypto_hash.sha256_digest, PAYLOAD)
+
+    assert result == hashlib.sha256(PAYLOAD).digest()
+    assert _mean_seconds(benchmark) < 15e-6
+
+
+@pytest.mark.benchmark(group="crypto_hash")
+def test_payload_map_hashing_under_15_microseconds_per_packet(benchmark):
+    payloads = tuple(PAYLOAD + bytes([idx]) for idx in range(32))
+
+    digest_map = benchmark(crypto_hash.digest_payload_map, payloads)
+    per_packet_mean = _mean_seconds(benchmark) / len(payloads)
+
+    assert crypto_hash.verify_digest_map(digest_map)
+    assert per_packet_mean < 15e-6


### PR DESCRIPTION
I added a fast SHA-256 utility that binds to CPython’s C-backed OpenSSL/hashlib implementation at import time, with graceful fallback and benchmarks for validator payload digest mapping.

closes #623