### PR TITLE
feat(serialization): integrate msgpack binary serializer for Redis ca…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ aiohttp>=3.9.0
 
 # Async PostgreSQL driver for high-performance bulk inserts
 asyncpg>=0.28.0
+
+# MsgPack binary serialisation with C-extensions for Redis cache payloads
+msgpack>=1.0.0

--- a/src/serialization/encoders.py
+++ b/src/serialization/encoders.py
@@ -34,6 +34,8 @@ Total frame size: 8 + 8 + 8 + 8 + 4 + 2 + 1 + 1 = 40 bytes
 import struct
 from typing import NamedTuple, Sequence, Union
 
+import msgpack
+
 # Format string & compile-time size
 # Using '<' for little-endian standard sizes and no implicit alignment padding.
 # The format '<8sqQQIHBB' defines the 40-byte unaligned layout:
@@ -47,6 +49,7 @@ from typing import NamedTuple, Sequence, Union
 # - B: 8-bit unsigned reserved byte
 _FRAME_STRUCT: struct.Struct = struct.Struct("<8sqQQIHBB")
 _FRAME_SIZE: int = _FRAME_STRUCT.size  # 40 bytes
+FRAME_SIZE: int = _FRAME_SIZE
 
 # Status-flag bitmask constants (uint16)
 FLAG_LIVE: int = 0x0001       # feed is live / real-time
@@ -163,28 +166,14 @@ def pack_frame(frame: TelemetryFrame) -> bytes:
 
 
 
-def pack_frame(frame: TelemetryFrame) -> bytes:
-    """Serialize a single TelemetryFrame into a FlatBuffers buffer."""
-    builder = flatbuffers.Builder(0)
-    
-    # Create asset_id vector
-    asset_bytes = frame.asset_id
-    asset_offset = builder.CreateByteVector(asset_bytes)
-    
-    # Build the TelemetryFrame
-    TelemetryFrameStart(builder)
-    TelemetryFrameAddAssetId(builder, asset_offset)
-    TelemetryFrameAddPrice(builder, frame.price)
-    TelemetryFrameAddVolume(builder, frame.volume)
-    TelemetryFrameAddTimestamp(builder, frame.timestamp)
-    TelemetryFrameAddSequence(builder, frame.sequence)
-    TelemetryFrameAddFlags(builder, frame.flags)
-    TelemetryFrameAddFeedId(builder, frame.feed_id)
-    frame_offset = TelemetryFrameEnd(builder)
-    
-    builder.Finish(frame_offset)
-    return bytes(builder.Output())
+def unpack_frame(data: bytes) -> TelemetryFrame:
+    """Unpack a raw 40-byte buffer back into a :class:`TelemetryFrame`.
 
+    Args:
+        data: A 40-byte buffer produced by :func:`pack_frame`.
+
+    Returns:
+        A populated :class:`TelemetryFrame` instance.
 
     Raises:
         struct.error: If ``data`` is shorter than ``FRAME_SIZE``.
@@ -603,6 +592,208 @@ class StructPackEncoder:
 
 
 # ---------------------------------------------------------------------------
+# Issue #628 — MsgPack binary serializer for Redis payload caching
+# ---------------------------------------------------------------------------
+# Uses msgpack with C-extensions for high-performance binary serialization
+# of Redis telemetry caches, reducing payload sizes by ~35%+ vs JSON strings.
+
+
+def msgpack_encode(obj: object) -> bytes:
+    """Encode *obj* into a compact msgpack binary payload.
+
+    Uses the C-accelerated ``msgpack.packb`` with ``use_bin_type=True`` so
+    that ``bytes`` values round-trip correctly and small integers are encoded
+    in their most compact wire representation.
+
+    Args:
+        obj: Any JSON-serialisable Python object (dict, list, int, float,
+             str, bytes, bool, None) — or any object supported by msgpack.
+
+    Returns:
+        A ``bytes`` object containing the msgpack-encoded representation.
+    """
+    return msgpack.packb(obj, use_bin_type=True, strict_types=True)
+
+
+def msgpack_decode(data: bytes) -> object:
+    """Decode a msgpack binary payload back into a Python object.
+
+    Args:
+        data: A ``bytes`` object previously produced by :func:`msgpack_encode`.
+
+    Returns:
+        The deserialised Python object.
+    """
+    return msgpack.unpackb(data, raw=False)
+
+
+_TELEMETRY_MSGPACK_VERSION: int = 1
+
+
+def msgpack_encode_telemetry_frame(frame: TelemetryFrame) -> bytes:
+    """Encode a :class:`TelemetryFrame` into a compact msgpack binary payload.
+
+    Uses a positional list layout (version byte + 7 values) to eliminate
+    per-key overhead and maximise compression — suitable for high-frequency
+    Redis telemetry caches where every byte counts.
+
+    Wire layout::
+
+        [version=1, asset_id, price, volume, timestamp, sequence, flags, feed_id]
+
+    Args:
+        frame: A populated :class:`TelemetryFrame` instance.
+
+    Returns:
+        A ``bytes`` object containing the msgpack-encoded frame.
+    """
+    return msgpack.packb(
+        [_TELEMETRY_MSGPACK_VERSION, frame.asset_id, frame.price,
+         frame.volume, frame.timestamp, frame.sequence, frame.flags,
+         frame.feed_id],
+        use_bin_type=True,
+        strict_types=True,
+    )
+
+
+def msgpack_decode_telemetry_frame(data: bytes) -> TelemetryFrame:
+    """Decode a msgpack payload back into a :class:`TelemetryFrame`.
+
+    Args:
+        data: A ``bytes`` object produced by
+              :func:`msgpack_encode_telemetry_frame`.
+
+    Returns:
+        A populated :class:`TelemetryFrame` instance.
+
+    Raises:
+        ValueError: If the version byte is unrecognised.
+    """
+    items = msgpack.unpackb(data, raw=False)
+    version = items[0]
+    if version != _TELEMETRY_MSGPACK_VERSION:
+        raise ValueError(f"Unsupported telemetry msgpack version: {version}")
+    return TelemetryFrame(
+        asset_id=items[1] if isinstance(items[1], bytes) else items[1].encode("ascii"),
+        price=items[2],
+        volume=items[3],
+        timestamp=items[4],
+        sequence=items[5],
+        flags=items[6],
+        feed_id=items[7],
+    )
+
+
+_RING_BUFFER_MSGPACK_VERSION: int = 1
+
+
+def msgpack_encode_ring_buffer_metric(metric: RingBufferMetric) -> bytes:
+    """Encode a :class:`RingBufferMetric` into a compact msgpack binary payload.
+
+    Uses a positional list layout for minimal wire size.
+
+    Args:
+        metric: A populated :class:`RingBufferMetric` instance.
+
+    Returns:
+        A ``bytes`` object containing the msgpack-encoded metric.
+    """
+    return msgpack.packb(
+        [_RING_BUFFER_MSGPACK_VERSION, metric.size, metric.capacity,
+         metric.utilization, metric.total_enqueued, metric.total_dequeued,
+         metric.enqueue_failures, metric.dequeue_failures, metric.avg_latency_us,
+         metric.peak_latency_us, metric.batches_processed],
+        use_bin_type=True,
+        strict_types=True,
+    )
+
+
+def msgpack_decode_ring_buffer_metric(data: bytes) -> RingBufferMetric:
+    """Decode a msgpack payload back into a :class:`RingBufferMetric`.
+
+    Args:
+        data: A ``bytes`` object produced by
+              :func:`msgpack_encode_ring_buffer_metric`.
+
+    Returns:
+        A populated :class:`RingBufferMetric` instance.
+    """
+    items = msgpack.unpackb(data, raw=False)
+    version = items[0]
+    if version != _RING_BUFFER_MSGPACK_VERSION:
+        raise ValueError(f"Unsupported ring-buffer msgpack version: {version}")
+    return RingBufferMetric(
+        size=items[1],
+        capacity=items[2],
+        utilization=items[3],
+        total_enqueued=items[4],
+        total_dequeued=items[5],
+        enqueue_failures=items[6],
+        dequeue_failures=items[7],
+        avg_latency_us=items[8],
+        peak_latency_us=items[9],
+        batches_processed=items[10],
+    )
+
+
+_BACKPRESSURE_MSGPACK_VERSION: int = 1
+
+
+def msgpack_encode_backpressure_metric(metric: BackpressureMetric) -> bytes:
+    """Encode a :class:`BackpressureMetric` into a compact msgpack binary payload.
+
+    Uses a positional list layout for minimal wire size.
+
+    Args:
+        metric: A populated :class:`BackpressureMetric` instance.
+
+    Returns:
+        A ``bytes`` object containing the msgpack-encoded metric.
+    """
+    return msgpack.packb(
+        [_BACKPRESSURE_MSGPACK_VERSION, metric.queue_length, metric.max_capacity,
+         metric.saturation, metric.dropped_packets, metric.slowed_ingestions,
+         metric.avg_processing_us],
+        use_bin_type=True,
+        strict_types=True,
+    )
+
+
+def msgpack_decode_backpressure_metric(data: bytes) -> BackpressureMetric:
+    """Decode a msgpack payload back into a :class:`BackpressureMetric`.
+
+    Args:
+        data: A ``bytes`` object produced by
+              :func:`msgpack_encode_backpressure_metric`.
+
+    Returns:
+        A populated :class:`BackpressureMetric` instance.
+    """
+    items = msgpack.unpackb(data, raw=False)
+    version = items[0]
+    if version != _BACKPRESSURE_MSGPACK_VERSION:
+        raise ValueError(f"Unsupported backpressure msgpack version: {version}")
+    return BackpressureMetric(
+        queue_length=items[1],
+        max_capacity=items[2],
+        saturation=items[3],
+        dropped_packets=items[4],
+        slowed_ingestions=items[5],
+        avg_processing_us=items[6],
+    )
+
+
+def msgpack_json_size(data: object) -> int:
+    """Return the byte length of *data* encoded as a JSON string.
+
+    This is a convenience helper for comparison tests that need the JSON
+    baseline size alongside the msgpack size.
+    """
+    import json
+    return len(json.dumps(data, separators=(",", ":")).encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
 # Public API
 __all__ = [
     "TelemetryFrame",
@@ -632,4 +823,14 @@ __all__ = [
     "FRAME_SIZE",
     # Issue #613 — struct-pack IPC encoder
     "StructPackEncoder",
+    # Issue #628 — msgpack binary serializer for Redis caching
+    "msgpack_encode",
+    "msgpack_decode",
+    "msgpack_encode_telemetry_frame",
+    "msgpack_decode_telemetry_frame",
+    "msgpack_encode_ring_buffer_metric",
+    "msgpack_decode_ring_buffer_metric",
+    "msgpack_encode_backpressure_metric",
+    "msgpack_decode_backpressure_metric",
+    "msgpack_json_size",
 ]

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,0 +1,258 @@
+"""Tests for src.serialization.encoders — msgpack binary serializer (Issue #628)."""
+import json
+import unittest
+
+from src.serialization.encoders import (
+    TelemetryFrame,
+    RingBufferMetric,
+    BackpressureMetric,
+    FLAG_LIVE,
+    FLAG_STALE,
+    FLAG_ANOMALY,
+    FLAG_SYNTHETIC,
+    FLAG_HALTED,
+    FRAME_SIZE,
+    TelemetryEncoder,
+    StructPackEncoder,
+    msgpack_encode,
+    msgpack_decode,
+    msgpack_encode_telemetry_frame,
+    msgpack_decode_telemetry_frame,
+    msgpack_encode_ring_buffer_metric,
+    msgpack_decode_ring_buffer_metric,
+    msgpack_encode_backpressure_metric,
+    msgpack_decode_backpressure_metric,
+)
+
+
+class TestMsgpackEncoding(unittest.TestCase):
+    """Verify msgpack encode/decode round-trips and size reductions vs JSON."""
+
+    # ---- helpers ----
+
+    def _sample_frame(self, **overrides) -> TelemetryFrame:
+        defaults = dict(
+            asset_id=b"NGN/XLM",
+            price=15_000_000,
+            volume=8_200_000,
+            timestamp=1_700_000_000_000,
+            sequence=42,
+            flags=FLAG_LIVE | FLAG_ANOMALY,
+            feed_id=3,
+        )
+        defaults.update(overrides)
+        return TelemetryFrame(**defaults)
+
+    def _sample_ring_buffer(self, **overrides) -> RingBufferMetric:
+        defaults = dict(
+            size=128,
+            capacity=1024,
+            utilization=7_500_000,
+            total_enqueued=9_999_999,
+            total_dequeued=9_999_871,
+            enqueue_failures=128,
+            dequeue_failures=0,
+            avg_latency_us=1_500_000,
+            peak_latency_us=12_000_000,
+            batches_processed=4_000,
+        )
+        defaults.update(overrides)
+        return RingBufferMetric(**defaults)
+
+    def _sample_backpressure(self, **overrides) -> BackpressureMetric:
+        defaults = dict(
+            queue_length=512,
+            max_capacity=2048,
+            saturation=3_330_000,
+            dropped_packets=7,
+            slowed_ingestions=42,
+            avg_processing_us=2_000_000,
+        )
+        defaults.update(overrides)
+        return BackpressureMetric(**defaults)
+
+    # ---- generic msgpack round-trip ----
+
+    def test_msgpack_roundtrip_basic_types(self) -> None:
+        for obj in [
+            {"a": 1, "b": [2, 3]},
+            [1, 2, 3],
+            "hello",
+            42,
+            3.14,
+            True,
+            None,
+            b"\x00\x01\x02",
+        ]:
+            with self.subTest(obj=obj):
+                self.assertEqual(msgpack_decode(msgpack_encode(obj)), obj)
+
+    # ---- TelemetryFrame msgpack round-trip ----
+
+    def test_telemetry_frame_roundtrip(self) -> None:
+        frame = self._sample_frame()
+        encoded = msgpack_encode_telemetry_frame(frame)
+        decoded = msgpack_decode_telemetry_frame(encoded)
+        self.assertEqual(decoded, frame)
+
+    # ---- RingBufferMetric msgpack round-trip ----
+
+    def test_ring_buffer_metric_roundtrip(self) -> None:
+        metric = self._sample_ring_buffer()
+        encoded = msgpack_encode_ring_buffer_metric(metric)
+        decoded = msgpack_decode_ring_buffer_metric(encoded)
+        self.assertEqual(decoded, metric)
+
+    # ---- BackpressureMetric msgpack round-trip ----
+
+    def test_backpressure_metric_roundtrip(self) -> None:
+        metric = self._sample_backpressure()
+        encoded = msgpack_encode_backpressure_metric(metric)
+        decoded = msgpack_decode_backpressure_metric(encoded)
+        self.assertEqual(decoded, metric)
+
+    # ---- Payload size reduction vs JSON ----
+
+    def test_msgpack_encoding(self) -> None:
+        """msgpack payloads must be >= 35 % smaller than JSON string equivalents."""
+        frames = [
+            self._sample_frame(
+                asset_id=b"NGN/XLM",
+                price=15_000_000,
+                volume=8_200_000,
+                timestamp=1_700_000_000_000,
+                sequence=i,
+                flags=FLAG_LIVE,
+                feed_id=1,
+            )
+            for i in range(10)
+        ]
+
+        for label, frames_subset in [("single_frame", frames[:1]), ("bundle_10", frames)]:
+            # Build a JSON-comparable dict representation
+            json_dicts = [
+                {
+                    "asset_id": f.asset_id.decode("ascii"),
+                    "price": f.price,
+                    "volume": f.volume,
+                    "timestamp": f.timestamp,
+                    "sequence": f.sequence,
+                    "flags": f.flags,
+                    "feed_id": f.feed_id,
+                }
+                for f in frames_subset
+            ]
+            json_payload = json.dumps(
+                json_dicts if len(json_dicts) > 1 else json_dicts[0],
+                separators=(",", ":"),
+            ).encode("utf-8")
+            json_size = len(json_payload)
+
+            # Msgpack payload — encode each frame individually, concatenate
+            msgpack_payload = b"".join(
+                msgpack_encode_telemetry_frame(f) for f in frames_subset
+            )
+            msgpack_size = len(msgpack_payload)
+
+            reduction_pct = (1 - msgpack_size / json_size) * 100
+            self.assertGreaterEqual(
+                reduction_pct,
+                35,
+                f"{label}: msgpack ({msgpack_size} B) not >= 35% smaller "
+                f"than JSON ({json_size} B) — only {reduction_pct:.1f}%",
+            )
+
+    # ---- RingBufferMetric size reduction ----
+
+    def test_ring_buffer_metric_size_reduction(self) -> None:
+        metric = self._sample_ring_buffer()
+        msgpack_data = msgpack_encode_ring_buffer_metric(metric)
+        json_data = json.dumps(
+            {
+                "size": metric.size,
+                "capacity": metric.capacity,
+                "utilization": metric.utilization,
+                "total_enqueued": metric.total_enqueued,
+                "total_dequeued": metric.total_dequeued,
+                "enqueue_failures": metric.enqueue_failures,
+                "dequeue_failures": metric.dequeue_failures,
+                "avg_latency_us": metric.avg_latency_us,
+                "peak_latency_us": metric.peak_latency_us,
+                "batches_processed": metric.batches_processed,
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        reduction_pct = (1 - len(msgpack_data) / len(json_data)) * 100
+        self.assertGreaterEqual(reduction_pct, 35)
+
+    # ---- BackpressureMetric size reduction ----
+
+    def test_backpressure_metric_size_reduction(self) -> None:
+        metric = self._sample_backpressure()
+        msgpack_data = msgpack_encode_backpressure_metric(metric)
+        json_data = json.dumps(
+            {
+                "queue_length": metric.queue_length,
+                "max_capacity": metric.max_capacity,
+                "saturation": metric.saturation,
+                "dropped_packets": metric.dropped_packets,
+                "slowed_ingestions": metric.slowed_ingestions,
+                "avg_processing_us": metric.avg_processing_us,
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        reduction_pct = (1 - len(msgpack_data) / len(json_data)) * 100
+        self.assertGreaterEqual(reduction_pct, 35)
+
+
+class TestStructPackEncoder(unittest.TestCase):
+    """Issue #613 — struct-pack IPC encoder smoke tests."""
+
+    def test_encode_telemetry_frame(self) -> None:
+        enc = StructPackEncoder(channel_id=1)
+        frame = TelemetryFrame(
+            asset_id=b"NGN/XLM",
+            price=15_000_000,
+            volume=0,
+            timestamp=1_700_000_000_000,
+            sequence=1,
+            flags=FLAG_LIVE,
+            feed_id=3,
+        )
+        buf = enc.encode_telemetry_frame(frame)
+        self.assertEqual(len(buf), FRAME_SIZE + 24)  # 40 + 24-byte header
+
+    def test_decode_header(self) -> None:
+        enc = StructPackEncoder(channel_id=2)
+        frame = TelemetryFrame(b"USD/XLM", 1000, 2000, 1000000, 1, FLAG_STALE, 1)
+        buf = enc.encode_telemetry_frame(frame)
+        ptype, version, plen, seq, ts = StructPackEncoder.decode_header(buf)
+        self.assertEqual(ptype, 0x01)  # IPC_TYPE_TELEMETRY_FRAME
+        self.assertEqual(version, 1)
+        self.assertEqual(plen, FRAME_SIZE)
+
+    def test_scale(self) -> None:
+        self.assertEqual(StructPackEncoder.scale(1.5), 15_000_000)
+        self.assertEqual(StructPackEncoder.scale(0.0), 0)
+
+
+class TestTelemetryEncoderLegacy(unittest.TestCase):
+    """Smoke tests for the existing struct-based packer."""
+
+    def test_pack_unpack_roundtrip(self) -> None:
+        frame = TelemetryFrame(
+            asset_id=b"EUR/USD",
+            price=1_234_567,
+            volume=9_876_543,
+            timestamp=1_700_000_001_000,
+            sequence=7,
+            flags=FLAG_SYNTHETIC | FLAG_HALTED,
+            feed_id=9,
+        )
+        packed = TelemetryEncoder.pack(frame)
+        self.assertEqual(len(packed), FRAME_SIZE)
+        unpacked = TelemetryEncoder.unpack(packed)
+        self.assertEqual(unpacked, frame)
+
+    def test_frame_size_constant(self) -> None:
+        self.assertEqual(FRAME_SIZE, 40)


### PR DESCRIPTION
closes #628

- Add msgpack encode/decode functions for TelemetryFrame, RingBufferMetric, and BackpressureMetric using positional list layout for minimal wire size
- Wire format uses version-prefixed arrays to eliminate per-key overhead, achieving >= 35% payload size reduction vs JSON string representations
- Fix corrupted duplicate pack_frame and restore missing unpack_frame
- Add FRAME_SIZE module-level alias
- Add msgpack>=1.0.0 to requirements.txt
- Add tests/test_encoders.py with round-trip and size-reduction tests