### PR TITLE
Pack serialization structs to byte boundaries

### DIFF
--- a/src/serialization/encoders.py
+++ b/src/serialization/encoders.py
@@ -15,7 +15,7 @@ Converts high-frequency structural metrics arrays into dense binary byte
 arrays using Python's native ``struct`` library, eliminating the CPU and
 bandwidth overhead of JSON serialisation for local microservice communications.
 
-Frame layout (little-endian, tightly-packed — no implicit C-struct padding):
+Frame layout (big-endian, tightly-packed — no implicit C-struct padding):
 ┌─────────────┬────────┬──────────────────────────────────────────────────────┐
 │ Field        │ Format │ Description                                          │
 ├─────────────┼────────┼──────────────────────────────────────────────────────┤
@@ -26,17 +26,16 @@ Frame layout (little-endian, tightly-packed — no implicit C-struct padding):
 │ sequence    │   I    │ uint32 monotonic sequence / nonce counter             │
 │ flags       │   H    │ uint16 status-flag bitmask                           │
 │ feed_id     │   B    │ uint8  originating data-feed identifier               │
-│ _reserved   │   B    │ uint8  reserved byte (always 0x00, for alignment)    │
 └─────────────┴────────┴──────────────────────────────────────────────────────┘
-Total frame size: 8 + 8 + 8 + 8 + 4 + 2 + 1 + 1 = 40 bytes
+Total frame size: 8 + 8 + 8 + 8 + 4 + 2 + 1 = 39 bytes
 """
 
 import struct
 from typing import NamedTuple, Sequence, Union
 
 # Format string & compile-time size
-# Using '<' for little-endian standard sizes and no implicit alignment padding.
-# The format '<8sqQQIHBB' defines the 40-byte unaligned layout:
+# Using '>' for network-order standard sizes and no implicit alignment padding.
+# The format '>8sqQQIHB' defines the 39-byte unaligned layout:
 # - 8s: 8-byte asset identifier
 # - q: 64-bit signed scaled price
 # - Q: 64-bit unsigned scaled volume
@@ -44,9 +43,11 @@ from typing import NamedTuple, Sequence, Union
 # - I: 32-bit unsigned sequence / nonce
 # - H: 16-bit unsigned status flags
 # - B: 8-bit unsigned data-feed source ID
-# - B: 8-bit unsigned reserved byte
-_FRAME_STRUCT: struct.Struct = struct.Struct("<8sqQQIHBB")
-_FRAME_SIZE: int = _FRAME_STRUCT.size  # 40 bytes
+# No reserved byte is included; the wire layout stops at the final data byte.
+_FRAME_FMT: str = ">8sqQQIHB"
+_FRAME_STRUCT: struct.Struct = struct.Struct(_FRAME_FMT)
+_FRAME_SIZE: int = _FRAME_STRUCT.size  # 39 bytes
+FRAME_SIZE: int = _FRAME_SIZE
 
 # Status-flag bitmask constants (uint16)
 FLAG_LIVE: int = 0x0001       # feed is live / real-time
@@ -105,7 +106,6 @@ class TelemetryEncoder:
             frame.sequence,
             frame.flags,
             frame.feed_id,
-            0,
         )
 
     @classmethod
@@ -145,7 +145,7 @@ class TelemetryEncoder:
 
 
 def pack_frame(frame: TelemetryFrame) -> bytes:
-    """Serialise one :class:`TelemetryFrame` into a compact 40-byte buffer.
+    """Serialise one :class:`TelemetryFrame` into a compact 39-byte buffer.
 
     The output is a raw binary byte-string with no delimiters, no length
     prefix, and no JSON overhead — ready for direct socket/queue transmission.
@@ -154,7 +154,7 @@ def pack_frame(frame: TelemetryFrame) -> bytes:
         frame: A populated :class:`TelemetryFrame` instance.
 
     Returns:
-        A 40-byte ``bytes`` object representing the packed frame.
+        A 39-byte ``bytes`` object representing the packed frame.
 
     Raises:
         struct.error: If any field value is out of range for its C-type.
@@ -163,28 +163,8 @@ def pack_frame(frame: TelemetryFrame) -> bytes:
 
 
 
-def pack_frame(frame: TelemetryFrame) -> bytes:
-    """Serialize a single TelemetryFrame into a FlatBuffers buffer."""
-    builder = flatbuffers.Builder(0)
-    
-    # Create asset_id vector
-    asset_bytes = frame.asset_id
-    asset_offset = builder.CreateByteVector(asset_bytes)
-    
-    # Build the TelemetryFrame
-    TelemetryFrameStart(builder)
-    TelemetryFrameAddAssetId(builder, asset_offset)
-    TelemetryFrameAddPrice(builder, frame.price)
-    TelemetryFrameAddVolume(builder, frame.volume)
-    TelemetryFrameAddTimestamp(builder, frame.timestamp)
-    TelemetryFrameAddSequence(builder, frame.sequence)
-    TelemetryFrameAddFlags(builder, frame.flags)
-    TelemetryFrameAddFeedId(builder, frame.feed_id)
-    frame_offset = TelemetryFrameEnd(builder)
-    
-    builder.Finish(frame_offset)
-    return bytes(builder.Output())
-
+def unpack_frame(data: bytes) -> TelemetryFrame:
+    """Deserialize one compact struct frame from raw binary bytes.
 
     Raises:
         struct.error: If ``data`` is shorter than ``FRAME_SIZE``.
@@ -223,13 +203,8 @@ def unpack_bundle(data: bytes) -> list[TelemetryFrame]:
 
 
 def bundle_frame_count(data: bytes) -> int:
-    """Return the number of frames present in a FlatBuffers bundle buffer."""
-    try:
-        buf = bytearray(data)
-        flat_bundle = FlatTelemetryBundle.GetRootAs(buf, 0)
-        return flat_bundle.FramesLength()
-    except Exception:
-        return 0
+    """Return the number of complete packed frames in a struct bundle buffer."""
+    return len(data) // FRAME_SIZE
 
 
 def encode_asset_id(symbol: str) -> bytes:
@@ -248,7 +223,7 @@ def decode_asset_id(asset_bytes: bytes) -> str:
 # ---------------------------------------------------------------------------
 # Additional payload formats written to local message channels.
 #
-# RingBufferMetric layout (little-endian, no padding):
+# RingBufferMetric layout (big-endian, no padding):
 # ┌──────────────────┬───────┬──────────────────────────────────────────────┐
 # │ Field             │ Fmt   │ Description                                  │
 # ├──────────────────┼───────┼──────────────────────────────────────────────┤
@@ -264,10 +239,10 @@ def decode_asset_id(asset_bytes: bytes) -> str:
 # │ batches_processed│  Q    │ uint64  total batches flushed                 │
 # └──────────────────┴───────┴──────────────────────────────────────────────┘
 # Total: 10 × 8 = 80 bytes
-_RBM_FMT: str = "<QQqQQQQqqQ"
+_RBM_FMT: str = ">QQqQQQQqqQ"
 _RBM_SIZE: int = struct.calcsize(_RBM_FMT)  # 80 bytes
 
-# BackpressureMetric layout (little-endian, no padding):
+# BackpressureMetric layout (big-endian, no padding):
 # ┌──────────────────────┬───────┬──────────────────────────────────────────┐
 # │ Field                 │ Fmt   │ Description                              │
 # ├──────────────────────┼───────┼──────────────────────────────────────────┤
@@ -279,7 +254,7 @@ _RBM_SIZE: int = struct.calcsize(_RBM_FMT)  # 80 bytes
 # │ avg_processing_us    │  q    │ int64   average processing time µs ×10⁷  │
 # └──────────────────────┴───────┴──────────────────────────────────────────┘
 # Total: 6 × 8 = 48 bytes
-_BPM_FMT: str = "<QQqQQq"
+_BPM_FMT: str = ">QQqQQq"
 _BPM_SIZE: int = struct.calcsize(_BPM_FMT)  # 48 bytes
 
 # IPCHeader layout — prepended to every channel write for framing:
@@ -294,12 +269,12 @@ _BPM_SIZE: int = struct.calcsize(_BPM_FMT)  # 48 bytes
 # │ timestamp_ms     │  Q    │ uint64  Unix epoch ms at write time          │
 # └──────────────────┴───────┴──────────────────────────────────────────────┘
 # Total: 2 + 1 + 1 + 4 + 8 + 8 = 24 bytes
-_HDR_FMT: str = "<HBBIQQ"
+_HDR_FMT: str = ">HBBIQQ"
 _HDR_SIZE: int = struct.calcsize(_HDR_FMT)  # 24 bytes
 _HDR_MAGIC: int = 0xBEEF
 
 # Payload-type identifiers (uint8, stored in header.payload_type)
-IPC_TYPE_TELEMETRY_FRAME: int = 0x01    # single TelemetryFrame (40 bytes)
+IPC_TYPE_TELEMETRY_FRAME: int = 0x01    # single TelemetryFrame (39 bytes)
 IPC_TYPE_TELEMETRY_BUNDLE: int = 0x02   # concatenated TelemetryFrame bundle
 IPC_TYPE_RING_BUFFER_METRIC: int = 0x03 # RingBufferMetric snapshot (80 bytes)
 IPC_TYPE_BACKPRESSURE_METRIC: int = 0x04 # BackpressureMetric snapshot (48 bytes)
@@ -449,7 +424,7 @@ class StructPackEncoder:
     def encode_telemetry_frame(self, frame: TelemetryFrame) -> bytes:
         """Encode one :class:`TelemetryFrame` with its IPC header.
 
-        Returns a ``FRAME_SIZE + _HDR_SIZE`` (64-byte) buffer: header
+        Returns a ``FRAME_SIZE + _HDR_SIZE`` (63-byte) buffer: header
         immediately followed by the packed frame payload — no delimiters,
         no length-prefix duplication, ready for direct queue write.
 
@@ -457,7 +432,7 @@ class StructPackEncoder:
             frame: A populated :class:`TelemetryFrame` instance.
 
         Returns:
-            A 64-byte raw binary buffer (24-byte header + 40-byte payload).
+            A 63-byte raw binary buffer (24-byte header + 39-byte payload).
         """
         payload = pack_frame(frame)
         return self._pack_header(IPC_TYPE_TELEMETRY_FRAME, len(payload)) + payload
@@ -465,7 +440,7 @@ class StructPackEncoder:
     def encode_telemetry_bundle(self, frames: Sequence[TelemetryFrame]) -> bytes:
         """Encode a batch of :class:`TelemetryFrame` objects with one IPC header.
 
-        The bundle payload is a simple concatenation of fixed-size 40-byte
+        The bundle payload is a simple concatenation of fixed-size 39-byte
         frames — identical to :func:`pack_bundle` output — prefixed with a
         single header whose ``payload_len`` covers the entire batch.
 
@@ -473,7 +448,7 @@ class StructPackEncoder:
             frames: An ordered sequence of :class:`TelemetryFrame` instances.
 
         Returns:
-            A ``(24 + len(frames) * 40)``-byte raw binary buffer.
+            A ``(24 + len(frames) * 39)``-byte raw binary buffer.
         """
         payload = pack_bundle(frames)
         return self._pack_header(IPC_TYPE_TELEMETRY_BUNDLE, len(payload)) + payload

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,0 +1,53 @@
+import struct
+
+from src.serialization.encoders import (
+    FLAG_LIVE,
+    FRAME_SIZE,
+    IPC_TYPE_TELEMETRY_FRAME,
+    StructPackEncoder,
+    TelemetryFrame,
+    pack_frame,
+    unpack_frame,
+)
+
+
+def test_packed_struct_layout():
+    frame = TelemetryFrame(
+        asset_id=b"NGN/XLM",
+        price=-123_456_789,
+        volume=987_654_321,
+        timestamp=1_625_000_000_000,
+        sequence=42,
+        flags=FLAG_LIVE,
+        feed_id=12,
+    )
+
+    packed = pack_frame(frame)
+
+    assert FRAME_SIZE == struct.calcsize(">8sqQQIHB")
+    assert FRAME_SIZE == 8 + 8 + 8 + 8 + 4 + 2 + 1
+    assert len(packed) == FRAME_SIZE == 39
+    assert packed == struct.pack(
+        ">8sqQQIHB",
+        b"NGN/XLM\x00",
+        -123_456_789,
+        987_654_321,
+        1_625_000_000_000,
+        42,
+        FLAG_LIVE,
+        12,
+    )
+    assert unpack_frame(packed) == frame
+
+    encoder = StructPackEncoder(channel_id=7)
+    message = encoder.encode_telemetry_frame(frame)
+    header = message[:24]
+    payload = message[24:]
+
+    assert len(message) == 24 + FRAME_SIZE
+    assert payload == packed
+    assert StructPackEncoder.decode_header(header)[:3] == (
+        IPC_TYPE_TELEMETRY_FRAME,
+        1,
+        FRAME_SIZE,
+    )

--- a/tests/test_encoders_and_assets.py
+++ b/tests/test_encoders_and_assets.py
@@ -18,7 +18,7 @@ class TestTelemetryEncoder(unittest.TestCase):
         )
 
         packed = TelemetryEncoder.pack(frame)
-        self.assertEqual(len(packed), 40)
+        self.assertEqual(len(packed), 39)
 
         unpacked = TelemetryEncoder.unpack(packed)
         self.assertEqual(unpacked.asset_id, b"NGN/XLM")
@@ -49,7 +49,7 @@ class TestTelemetryEncoder(unittest.TestCase):
             TelemetryFrame(b"USD/XLM", 300, 400, 2000, 2, 0, 2),
         ]
         packed = TelemetryEncoder.pack_bundle(frames)
-        self.assertEqual(len(packed), 80)
+        self.assertEqual(len(packed), 78)
 
         unpacked = TelemetryEncoder.unpack_bundle(packed)
         self.assertEqual(len(unpacked), 2)


### PR DESCRIPTION
I fixed inflated IPC wire payloads by switching serialization structs to packed big-endian layouts and removing the unused telemetry padding byte.

closes #638