### PR TITLE
feat: add transaction latency telemetry to NonceTracker

### DIFF
--- a/src/network/nonce_tracker.py
+++ b/src/network/nonce_tracker.py
@@ -429,11 +429,19 @@ class NonceTracker:
         Time: O(1).
         """
         lock = self._get_lock(address)
+        latency_ms = 0.0
         with lock:
             pending = self._pending.get(address)
             if pending is not None:
-                pending.pop(nonce, None)
-        logger.info("[NonceTracker] Confirmed nonce %d for %s", nonce, address)
+                info = pending.pop(nonce, None)
+                if info is not None:
+                    latency_ms = (time.monotonic() - info.issued_at) * 1000
+        logger.info(
+            "[NonceTracker] Confirmed nonce %d for %s | latency=%.1fms",
+            nonce,
+            address,
+            latency_ms,
+        )
 
     def fail(self, address: str, nonce: int) -> None:
         """Mark *nonce* as failed (rejected or dropped) and stop tracking it.
@@ -446,11 +454,19 @@ class NonceTracker:
         Time: O(1).
         """
         lock = self._get_lock(address)
+        latency_ms = 0.0
         with lock:
             pending = self._pending.get(address)
             if pending is not None:
-                pending.pop(nonce, None)
-        logger.info("[NonceTracker] Failed nonce %d for %s", nonce, address)
+                info = pending.pop(nonce, None)
+                if info is not None:
+                    latency_ms = (time.monotonic() - info.issued_at) * 1000
+        logger.info(
+            "[NonceTracker] Failed nonce %d for %s | latency=%.1fms",
+            nonce,
+            address,
+            latency_ms,
+        )
 
     def get_stale(
         self, address: str, timeout_seconds: float = DEFAULT_STALE_TIMEOUT_SECONDS

--- a/tests/test_nonce_tracker.py
+++ b/tests/test_nonce_tracker.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
@@ -926,4 +928,32 @@ def test_gap_report_stale_equals_current_is_not_a_gap() -> None:
         current_nonce=105,
     )
     assert not report.has_gaps
+
+
+# ===========================================================================
+# Transaction latency tracking  —  Issue #671
+# ===========================================================================
+
+
+def test_transaction_latency_tracking(caplog: pytest.LogCaptureFixture) -> None:
+    """Latency is computed and logged on both confirm and fail paths."""
+    tracker = NonceTracker.create_standalone()
+
+    caplog.set_level(logging.INFO)
+
+    # Confirm path
+    tracker.get_next_nonce("GA", seed=100)
+    time.sleep(0.01)
+    tracker.confirm("GA", 100)
+
+    # Fail path
+    tracker.get_next_nonce("GA")
+    time.sleep(0.01)
+    tracker.fail("GA", 101)
+
+    # Both outcomes logged with latency
+    assert "Confirmed nonce 100" in caplog.text
+    assert "Failed nonce 101" in caplog.text
+    assert "latency=" in caplog.text
+    assert "latency=0.0ms" not in caplog.text
 


### PR DESCRIPTION
## Summary

Implements transaction inclusion latency telemetry by recording and logging the elapsed time between nonce issuance and transaction resolution.

## Changes

- Compute transaction latency in `NonceTracker.confirm()` and `NonceTracker.fail()` using the existing `issued_at` timestamp.
- Append `latency=XX.Xms` to the existing nonce confirmation/failure log messages.
- Preserve the existing logging format and `[NonceTracker]` prefix without introducing new abstractions or dependencies.
- Add `test_transaction_latency_tracking` to verify latency is logged for both confirmed and failed transactions using `caplog`.

## How It Works

`TxManager.broadcast()` already invokes `NonceTracker.confirm()` and `NonceTracker.fail()` after transaction dispatch. As a result, every transaction processed through the existing flow automatically emits submission-to-resolution latency with no additional wiring or call-site changes.

Example log output:

```text
[NonceTracker] Confirmed nonce 42 for GABC... | latency=18.4ms
[NonceTracker] Failed nonce 43 for GABC... | latency=27.1ms
```

## Testing

```bash
pytest tests/test_nonce_tracker.py -k test_transaction_latency_tracking
```

- Added coverage for both confirm and fail paths.
- Verified non-zero latency is logged.
- All 48 tests in `tests/test_nonce_tracker.py` pass.

Closes #671