### PR TITLE
security(crypto): enforce context-managed key isolation with explicit overwrite sweep

### DIFF
--- a/src/crypto/signer.py
+++ b/src/crypto/signer.py
@@ -675,10 +675,6 @@ def _wipe_bytes_view(view: bytes) -> None:
         pass
 
 
-class SigningError(Exception):
-    """Raised when signing fails or the key handle is no longer usable."""
-
-
 class SecureKeyHandle:
     """
     Context manager that keeps private-key material isolated.
@@ -749,20 +745,33 @@ class SecureKeyHandle:
             pass
 
     def _do_wipe(self) -> None:
-        """Idempotently wipe and unlock the internal key buffer."""
+        """Idempotently wipe and unlock the internal key buffer.
+
+        Execution order is critical:
+        1. Zero-wipe the bytearray with ctypes.memset (Layer 1 overwrite sweep).
+        2. Release the mlock / sodium lock AFTER the wipe so the OS never
+           evicts live key material to swap during the window between unlock
+           and wipe.
+        3. Tear down the IsolatedMemoryHeap (its own wipe + PROT_NONE + unmap).
+        4. Emit an audit entry confirming the cleanup.
+        """
         if self._wiped:
             return
 
         self._wiped = True
 
-        try:
-            _zero_wipe(self._buf)
-        finally:
-            _unlock_memory(self._buf)
+        # Layer 1: immediate byte-clearing overwrite via ctypes.memset.
+        _zero_wipe(
+            self._buf,
+            audit_details={"object_type": "SecureKeyHandle"},
+        )
 
-        # Tear down the isolated mmap heap (wipes + mprotect-to-NONE +
-        # unmaps) so the canonical key copy leaves no recoverable trace
-        # in the process address space (Issue #660).
+        # Layer 2: release memory lock only after the overwrite is done.
+        if self._locked:
+            _munlock_buffer(self._buf)
+            self._locked = False
+
+        # Layer 3: tear down the isolated mmap heap — wipes + PROT_NONE + unmaps.
         heap_obj = getattr(self, "_heap", None)
         if heap_obj is not None:
             try:
@@ -771,6 +780,7 @@ class SecureKeyHandle:
                 pass
 
         logger.debug("[SecureKeyHandle] Signing scope closed — key wiped.")
+        audit_log.log_key_revoked(self._key_id, reason="scope_exit")
 
     def sign(self, tx_hash: bytes) -> bytes:
         """Sign a 32-byte transaction hash."""
@@ -815,7 +825,10 @@ class SecureKeyHandle:
             except ImportError:
                 return self._try_pynacl(key_bytes, tx_hash)
         finally:
-            _wipe_bytes_view(key_bytes)
+            # Overwrite the transient bytes copy in-place before releasing
+            # the reference, so the CPython object's internal buffer is
+            # zeroed while it is still uniquely held on this call stack.
+            _wipe_bytes_object(key_bytes)
             del key_bytes
 
     @staticmethod


### PR DESCRIPTION
closes #615 

- Remove duplicate SigningError class definition that silently shadowed the canonical exception type defined near the other exception classes.

- Fix SecureKeyHandle._do_wipe to call _munlock_buffer (respecting the _locked flag set by _mlock_buffer) instead of the legacy _unlock_memory helper that bypassed lock-state tracking. Unlock now always runs AFTER the zero-wipe, preventing the OS from evicting live key material to swap during the cleanup window. Adds audit log entry on scope close, matching SecureSessionCredentials and SecureVariableWrapper behavior.

- Fix _sign_internal transient copy wipe: replace _wipe_bytes_view (which zeroed only a copy-of-a-copy via from_buffer_copy) with _wipe_bytes_object (which uses ctypes.memset on id(obj)+offset to overwrite the CPython bytes object internal data buffer in-place). This closes the window where the transient key_bytes bytes object remained readable in heap memory after the signing routine returned.

Addresses: memory-dump extraction vulnerability where active private signing key material lingered in process memory after transaction signing completed.