### PR TITLE
feat(adapters): implement Anchor webhook receiver for SEP-24/SEP-31

### DIFF
--- a/app/adapters/anchor.py
+++ b/app/adapters/anchor.py
@@ -1,0 +1,106 @@
+import hashlib
+import hmac
+import json
+import logging
+import os
+from typing import Any, Dict
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from pydantic import BaseModel
+
+# Import the WebSocket connection manager to broadcast updates
+try:
+    from src.websockets.manager import manager
+except ImportError:
+    # Fallback/mock if running outside the main app context
+    manager = None
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/webhook/anchor", tags=["Anchor Webhooks"])
+
+# Read the secret from environment variables
+ANCHOR_WEBHOOK_SECRET = os.environ.get("ANCHOR_WEBHOOK_SECRET", "default_secret").encode("utf-8")
+
+
+class WebhookResponse(BaseModel):
+    success: bool
+    message: str
+
+
+def verify_hmac_signature(payload: bytes, signature: str, secret: bytes) -> bool:
+    """Verifies the HMAC-SHA256 signature of the webhook payload."""
+    if not signature:
+        return False
+        
+    expected_hmac = hmac.new(secret, payload, hashlib.sha256).hexdigest()
+    # Use hmac.compare_digest to prevent timing attacks
+    return hmac.compare_digest(expected_hmac, signature)
+
+
+async def transition_remittance_status(transaction_id: str, new_status: str) -> None:
+    """
+    Mock database function to transition the transaction status.
+    In a real implementation, this would use Prisma or asyncpg to update the record.
+    (PROCESSING -> DISPATCHED -> DELIVERED)
+    """
+    valid_statuses = ["PROCESSING", "DISPATCHED", "DELIVERED"]
+    if new_status not in valid_statuses:
+        logger.warning(f"Unexpected status '{new_status}' for transaction {transaction_id}")
+    
+    logger.info(f"Transitioning remittance transaction {transaction_id} to status: {new_status}")
+    # TODO: Implement actual database update here when the Remittance schema is added.
+
+
+@router.post("", response_model=WebhookResponse)
+async def receive_anchor_webhook(
+    request: Request,
+    x_anchor_signature: str = Header(None, alias="X-Anchor-Signature")
+):
+    """
+    Handle incoming webhook status updates from financial anchor partners
+    regarding fiat payout completion status.
+    """
+    # 1. Read raw body for HMAC verification
+    raw_body = await request.body()
+    
+    # 2. Validate HMAC-SHA256 signature
+    if not verify_hmac_signature(raw_body, x_anchor_signature, ANCHOR_WEBHOOK_SECRET):
+        logger.warning("Invalid or missing X-Anchor-Signature on incoming webhook.")
+        raise HTTPException(status_code=401, detail="Invalid HMAC signature")
+        
+    try:
+        # Parse JSON payload
+        payload = json.loads(raw_body.decode("utf-8"))
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON payload")
+
+    # The payload structure is expected to follow SEP-24 / SEP-31 formats.
+    # Typically, it contains a 'transaction' object with an 'id' and a 'status'.
+    transaction = payload.get("transaction", {})
+    transaction_id = transaction.get("id")
+    status = transaction.get("status")
+    
+    if not transaction_id or not status:
+        logger.error(f"Malformed payload received: {payload}")
+        raise HTTPException(status_code=400, detail="Missing transaction id or status in payload")
+
+    status = status.upper()
+
+    # 3. Transition remittance transaction status in the database
+    await transition_remittance_status(transaction_id, status)
+
+    # 4. Broadcast real-time status update to frontend clients over WebSocket
+    if manager:
+        channel_name = f"remittance_{transaction_id}"
+        message = {
+            "transaction_id": transaction_id,
+            "status": status,
+            "event": "STATUS_UPDATE"
+        }
+        await manager.broadcast_to_channel(channel_name, message)
+        logger.info(f"Broadcasted status update to channel {channel_name}")
+    else:
+        logger.warning("WebSocket manager not available. Broadcast skipped.")
+
+    return WebhookResponse(success=True, message="Webhook processed successfully")


### PR DESCRIPTION

Closes #720 

## Description
This PR implements the anchor-adapter module (`app/adapters/anchor.py`) to process incoming webhook status updates from financial anchor partners regarding fiat payout completion statuses for SEP-24 and SEP-31 transactions.

## Changes Included
- **HMAC-SHA256 Signature Validation**: Validates the payload against the provided `X-Anchor-Signature` using a safe `hmac.compare_digest` check to prevent timing attacks.
- **Transaction Status Transition**: Implemented the status transition mapping (`PROCESSING` ➔ `DISPATCHED` ➔ `DELIVERED`). Note that the database model is temporarily mocked until the `Remittance` schema is finalized.
- **Real-Time WebSockets**: Hooked into the existing connection manager to broadcast the state updates seamlessly to any frontend client subscribed to the transaction's channel.

## Checklist
- [x] Tested HMAC signature verification.
- [x] Verified atomic commit principles were adhered to (clean history, single logical change).
- [x] Linter and type-checker passing.
